### PR TITLE
feat(tools): add Document Sections API tools

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -286,6 +286,11 @@ describe("Tool Definitions", () => {
     { name: "search_passwords", requiredFields: [] as string[], properties: ["organization_id", "name", "password_category_id", "url", "username", "page_size", "page_number", "sort"] },
     { name: "get_password", requiredFields: ["id"], properties: ["id", "show_password"] },
     { name: "search_documents", requiredFields: ["organization_id"] as string[], properties: ["organization_id", "name", "page_size", "page_number", "sort"] },
+    { name: "list_document_sections", requiredFields: ["document_id"], properties: ["document_id"] },
+    { name: "create_document_section", requiredFields: ["document_id", "section_type", "content"], properties: ["document_id", "section_type", "content"] },
+    { name: "update_document_section", requiredFields: ["document_id", "section_id", "content"], properties: ["document_id", "section_id", "content"] },
+    { name: "delete_document_section", requiredFields: ["document_id", "section_id"], properties: ["document_id", "section_id"] },
+    { name: "publish_document", requiredFields: ["document_id"], properties: ["document_id"] },
     { name: "search_flexible_assets", requiredFields: ["flexible_asset_type_id"], properties: ["flexible_asset_type_id", "organization_id", "name", "page_size", "page_number", "sort"] },
     { name: "itglue_health_check", requiredFields: [] as string[], properties: [] as string[] },
   ];
@@ -301,8 +306,8 @@ describe("Tool Definitions", () => {
     });
   });
 
-  it("should have 9 tools total", () => {
-    expect(tools.length).toBe(9);
+  it("should have 14 tools total", () => {
+    expect(tools.length).toBe(14);
   });
 });
 
@@ -677,6 +682,104 @@ describe("Tool Handler Integration", () => {
       const json = (await response.json()) as JsonApiResponse;
 
       expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Security Policy");
+    });
+  });
+
+  describe("list_document_sections", () => {
+    it("should list sections for a document", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "1001", type: "document-sections", attributes: { content: "<h2>Overview</h2>", "section-type": "Document::Heading", position: 1 } },
+        { id: "1002", type: "document-sections", attributes: { content: "<p>Details here.</p>", "section-type": "Document::Text", position: 2 } },
+      ]);
+
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+
+      const response = await fetch("https://api.itglue.com/documents/789/relationships/sections");
+      const json = (await response.json()) as JsonApiResponse;
+
+      expect((json.data as JsonApiResource[]).length).toBe(2);
+      expect((json.data as JsonApiResource[])[0].attributes?.["section-type"]).toBe("Document::Heading");
+    });
+  });
+
+  describe("create_document_section", () => {
+    it("should map 'heading' type to Document::Heading", () => {
+      const sectionTypeMap: Record<string, string> = { heading: "Document::Heading", text: "Document::Text" };
+      expect(sectionTypeMap["heading"]).toBe("Document::Heading");
+    });
+
+    it("should map 'text' type to Document::Text", () => {
+      const sectionTypeMap: Record<string, string> = { heading: "Document::Heading", text: "Document::Text" };
+      expect(sectionTypeMap["text"]).toBe("Document::Text");
+    });
+
+    it("should post a new section to the sections endpoint", async () => {
+      const mockSection = { id: "1003", type: "document-sections", attributes: { content: "<p>New section.</p>", "section-type": "Document::Text" } };
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: mockSection, meta: {} }));
+
+      const response = await fetch("https://api.itglue.com/documents/789/relationships/sections", {
+        method: "POST",
+        headers: { "Content-Type": "application/vnd.api+json" },
+        body: JSON.stringify({ data: { type: "document-sections", attributes: { "section-type": "Document::Text", content: "<p>New section.</p>" } } }),
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.itglue.com/documents/789/relationships/sections",
+        expect.objectContaining({ method: "POST" })
+      );
+      expect(response.ok).toBe(true);
+    });
+  });
+
+  describe("update_document_section", () => {
+    it("should patch the section with new content", async () => {
+      const mockSection = { id: "1002", type: "document-sections", attributes: { content: "<p>Updated.</p>" } };
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: mockSection, meta: {} }));
+
+      const response = await fetch("https://api.itglue.com/documents/789/relationships/sections/1002", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/vnd.api+json" },
+        body: JSON.stringify({ data: { type: "document-sections", attributes: { content: "<p>Updated.</p>" } } }),
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.itglue.com/documents/789/relationships/sections/1002",
+        expect.objectContaining({ method: "PATCH" })
+      );
+      expect(response.ok).toBe(true);
+    });
+  });
+
+  describe("delete_document_section", () => {
+    it("should delete a section", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(null, 204));
+
+      const response = await fetch("https://api.itglue.com/documents/789/relationships/sections/1002", {
+        method: "DELETE",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.itglue.com/documents/789/relationships/sections/1002",
+        expect.objectContaining({ method: "DELETE" })
+      );
+      expect(response.status).toBe(204);
+    });
+  });
+
+  describe("publish_document", () => {
+    it("should use PATCH method (not POST)", async () => {
+      const mockDoc = { id: "789", type: "documents", attributes: { name: "My Doc" } };
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: mockDoc, meta: {} }));
+
+      const response = await fetch("https://api.itglue.com/documents/789/publish", {
+        method: "PATCH",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.itglue.com/documents/789/publish",
+        expect.objectContaining({ method: "PATCH" })
+      );
+      expect(response.ok).toBe(true);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,52 @@ class ITGlueClient {
     const resource = Array.isArray(json.data) ? json.data[0] : json.data;
     return deserializeResource(resource) as T;
   }
+
+  async patch<T>(path: string, body: Record<string, unknown> = {}): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: {
+        "x-api-key": this.apiKey,
+        "Content-Type": "application/vnd.api+json",
+        Accept: "application/vnd.api+json",
+      },
+      body: Object.keys(body).length > 0 ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`IT Glue API error (${response.status}): ${errorBody}`);
+    }
+
+    const json = (await response.json()) as JsonApiResponse;
+
+    if (json.errors && json.errors.length > 0) {
+      const errorMessages = json.errors.map((e) => e.detail || e.title).join(", ");
+      throw new Error(`IT Glue API error: ${errorMessages}`);
+    }
+
+    const resource = Array.isArray(json.data) ? json.data[0] : json.data;
+    return deserializeResource(resource) as T;
+  }
+
+  async delete(path: string): Promise<void> {
+    const url = `${this.baseUrl}${path}`;
+
+    const response = await fetch(url, {
+      method: "DELETE",
+      headers: {
+        "x-api-key": this.apiKey,
+        Accept: "application/vnd.api+json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`IT Glue API error (${response.status}): ${errorBody}`);
+    }
+  }
 }
 
 // Credential extraction from gateway headers
@@ -507,6 +553,98 @@ function createMcpServer(): Server {
             },
           },
           required: ["organization_id", "name"],
+        },
+      },
+      // Document Sections
+      {
+        name: "list_document_sections",
+        description: "List all sections of an IT Glue document in order. Use this to read document content before editing.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            document_id: {
+              type: "number",
+              description: "The document ID",
+            },
+          },
+          required: ["document_id"],
+        },
+      },
+      {
+        name: "create_document_section",
+        description: "Add a new section to an IT Glue document. Section types: 'heading' (Document::Heading) or 'text' (Document::Text). Call publish_document after editing.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            document_id: {
+              type: "number",
+              description: "The document ID",
+            },
+            section_type: {
+              type: "string",
+              enum: ["heading", "text"],
+              description: "Section type: 'heading' for Document::Heading, 'text' for Document::Text",
+            },
+            content: {
+              type: "string",
+              description: "HTML content for the section",
+            },
+          },
+          required: ["document_id", "section_type", "content"],
+        },
+      },
+      {
+        name: "update_document_section",
+        description: "Update the content of an existing IT Glue document section. Use list_document_sections to get section IDs. Call publish_document after editing.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            document_id: {
+              type: "number",
+              description: "The document ID",
+            },
+            section_id: {
+              type: "number",
+              description: "The section ID (from list_document_sections)",
+            },
+            content: {
+              type: "string",
+              description: "New HTML content for the section",
+            },
+          },
+          required: ["document_id", "section_id", "content"],
+        },
+      },
+      {
+        name: "delete_document_section",
+        description: "Delete a section from an IT Glue document. Call publish_document after editing.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            document_id: {
+              type: "number",
+              description: "The document ID",
+            },
+            section_id: {
+              type: "number",
+              description: "The section ID to delete (from list_document_sections)",
+            },
+          },
+          required: ["document_id", "section_id"],
+        },
+      },
+      {
+        name: "publish_document",
+        description: "Publish an IT Glue document to make section changes visible. Always call this after creating, updating, or deleting sections.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            document_id: {
+              type: "number",
+              description: "The document ID to publish",
+            },
+          },
+          required: ["document_id"],
         },
       },
       // Flexible Assets
@@ -825,6 +963,110 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         );
         return {
           content: [{ type: "text", text: JSON.stringify(newDoc, null, 2) }],
+        };
+      }
+
+      // Document Sections
+      case "list_document_sections": {
+        if (!args?.document_id) {
+          return {
+            content: [{ type: "text", text: "Error: document_id is required" }],
+            isError: true,
+          };
+        }
+        const result = await client.request(
+          `/documents/${args.document_id}/relationships/sections`,
+          {}
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "create_document_section": {
+        if (!args?.document_id || !args?.section_type || !args?.content) {
+          return {
+            content: [{ type: "text", text: "Error: document_id, section_type, and content are required" }],
+            isError: true,
+          };
+        }
+        const sectionTypeMap: Record<string, string> = {
+          heading: "Document::Heading",
+          text: "Document::Text",
+        };
+        const apiSectionType = sectionTypeMap[args.section_type as string];
+        if (!apiSectionType) {
+          return {
+            content: [{ type: "text", text: "Error: section_type must be 'heading' or 'text'" }],
+            isError: true,
+          };
+        }
+        const newSection = await client.post(
+          `/documents/${args.document_id}/relationships/sections`,
+          {
+            data: {
+              type: "document-sections",
+              attributes: {
+                "section-type": apiSectionType,
+                content: args.content,
+              },
+            },
+          }
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(newSection, null, 2) }],
+        };
+      }
+
+      case "update_document_section": {
+        if (!args?.document_id || !args?.section_id || !args?.content) {
+          return {
+            content: [{ type: "text", text: "Error: document_id, section_id, and content are required" }],
+            isError: true,
+          };
+        }
+        const updatedSection = await client.patch(
+          `/documents/${args.document_id}/relationships/sections/${args.section_id}`,
+          {
+            data: {
+              type: "document-sections",
+              attributes: {
+                content: args.content,
+              },
+            },
+          }
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(updatedSection, null, 2) }],
+        };
+      }
+
+      case "delete_document_section": {
+        if (!args?.document_id || !args?.section_id) {
+          return {
+            content: [{ type: "text", text: "Error: document_id and section_id are required" }],
+            isError: true,
+          };
+        }
+        await client.delete(
+          `/documents/${args.document_id}/relationships/sections/${args.section_id}`
+        );
+        return {
+          content: [{ type: "text", text: `Section ${args.section_id} deleted successfully` }],
+        };
+      }
+
+      case "publish_document": {
+        if (!args?.document_id) {
+          return {
+            content: [{ type: "text", text: "Error: document_id is required" }],
+            isError: true,
+          };
+        }
+        // Publish uses PATCH — POST returns 404
+        const published = await client.patch(`/documents/${args.document_id}/publish`);
+        return {
+          content: [{ type: "text", text: JSON.stringify(published, null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Summary

- Adds `patch()` and `delete()` methods to `ITGlueClient` (previously only had `get`, `post`, `request`)
- Adds 5 new MCP tools:
  - `list_document_sections` — GET `/documents/:id/relationships/sections`
  - `create_document_section` — POST with `heading`→`Document::Heading` / `text`→`Document::Text` type mapping
  - `update_document_section` — PATCH individual sections
  - `delete_document_section` — DELETE individual sections
  - `publish_document` — PATCH `/documents/:id/publish` (note: POST returns 404)
- Adds 12 new tests (100 total, up from 88)

## Key details

- `PATCH /documents/:id` with `content` attribute silently fails on multi-section docs — sections endpoints are required
- Publish must use PATCH not POST (POST returns 404, confirmed on EU server)
- Section types: `Document::Heading` and `Document::Text`

Related: wyre-technology/msp-claude-plugins#34 (skills/commands PR: wyre-technology/msp-claude-plugins#35)

## Test plan

- [x] All 100 unit tests pass
- [ ] Live test: `list_document_sections` on a known multi-section document
- [ ] Live test: `update_document_section` + `publish_document` roundtrip
- [ ] Verify on EU server (`api.eu.itglue.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)