### PR TITLE
fix(tools): add document folder ID filter to search_documents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -514,6 +514,10 @@ function createMcpServer(): Server {
               type: "string",
               description: "Sort field (prefix with - for descending)",
             },
+            document_folder_id: {
+              type: "number",
+              description: "Filter by document folder ID to search within a specific folder",
+            },
           },
           required: ["organization_id"],
         },
@@ -971,6 +975,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const filter: Record<string, unknown> = {};
 
         if (args?.name) filter.name = args.name;
+        if (args?.document_folder_id) filter.documentFolderId = args.document_folder_id;
 
         if (Object.keys(filter).length > 0) params.filter = filter;
         if (args?.sort) params.sort = args.sort;


### PR DESCRIPTION
## Summary
- Adds `document_folder_id` parameter to the `search_documents` MCP tool schema
- Maps the snake_case parameter to the camelCase `documentFolderId` filter in node-it-glue
- Enables users to search documents within a specific folder

Fixes wyre-technology/msp-claude-plugins#40

## Test plan
- [ ] Verify `search_documents` tool accepts `document_folder_id` parameter
- [ ] Test filtering documents by folder ID returns only documents in that folder
- [ ] Confirm searches without `document_folder_id` still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)