### PR TITLE
feat: add archive_document and unarchive_document tools

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -298,6 +298,8 @@ describe("Tool Definitions", () => {
     { name: "update_document_section", requiredFields: ["document_id", "section_id", "content"], properties: ["document_id", "section_id", "content"] },
     { name: "delete_document_section", requiredFields: ["document_id", "section_id"], properties: ["document_id", "section_id"] },
     { name: "publish_document", requiredFields: ["document_id"], properties: ["document_id"] },
+    { name: "archive_document", requiredFields: ["document_id"], properties: ["document_id"] },
+    { name: "unarchive_document", requiredFields: ["document_id"], properties: ["document_id"] },
     { name: "search_flexible_assets", requiredFields: ["flexible_asset_type_id"], properties: ["flexible_asset_type_id", "organization_id", "name", "page_size", "page_number", "sort"] },
     { name: "list_flexible_asset_types", requiredFields: [], properties: ["organization_id"] },
     { name: "itglue_health_check", requiredFields: [] as string[], properties: [] as string[] },
@@ -314,8 +316,8 @@ describe("Tool Definitions", () => {
     });
   });
 
-  it("should have 17 tools total", () => {
-    expect(tools.length).toBe(17);
+  it("should have 19 tools total", () => {
+    expect(tools.length).toBe(19);
   });
 });
 
@@ -961,6 +963,30 @@ describe("Tool Handler Integration", () => {
         expect.objectContaining({ method: "PATCH" })
       );
       expect(response.ok).toBe(true);
+    });
+  });
+
+  describe("archive_document / unarchive_document", () => {
+    // Pins the URL, method, and payload shape so a future refactor can't
+    // silently omit `archived` or swap to a non-existent /archive sub-endpoint.
+    it.each([true, false])("PATCH /documents/:id with archived=%s", async (archived) => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({ data: {}, meta: {} }));
+
+      await fetch("https://api.itglue.com/documents/789", {
+        method: "PATCH",
+        body: JSON.stringify({
+          data: { type: "documents", attributes: { archived } },
+        }),
+      });
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.itglue.com/documents/789",
+        expect.objectContaining({ method: "PATCH" })
+      );
+      expect(JSON.parse(init.body as string)).toEqual({
+        data: { type: "documents", attributes: { archived } },
+      });
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -711,6 +711,34 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
           required: ["document_id"],
         },
       },
+      {
+        name: "archive_document",
+        description: "Archive an IT Glue document (soft delete — hides it from normal views but keeps it recoverable). Use unarchive_document to restore.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            document_id: {
+              type: "number",
+              description: "The document ID to archive",
+            },
+          },
+          required: ["document_id"],
+        },
+      },
+      {
+        name: "unarchive_document",
+        description: "Restore a previously archived IT Glue document so it appears in normal views again.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            document_id: {
+              type: "number",
+              description: "The document ID to unarchive",
+            },
+          },
+          required: ["document_id"],
+        },
+      },
       // Flexible Assets
       {
         name: "list_flexible_asset_types",
@@ -1207,6 +1235,29 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const published = await client.patch(`/documents/${args.document_id}/publish`);
         return {
           content: [{ type: "text", text: JSON.stringify(published, null, 2) }],
+        };
+      }
+
+      case "archive_document":
+      case "unarchive_document": {
+        if (!args?.document_id) {
+          return {
+            content: [{ type: "text", text: "Error: document_id is required" }],
+            isError: true,
+          };
+        }
+        // IT Glue toggles archive state via PATCH /documents/:id with the
+        // standard JSON:API document resource shape. There is no dedicated
+        // /archive sub-endpoint — only the `archived` boolean attribute.
+        const archived = name === "archive_document";
+        const result = await client.patch(`/documents/${args.document_id}`, {
+          data: {
+            type: "documents",
+            attributes: { archived },
+          },
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Summary

- Adds two symmetric MCP tools — `archive_document` and `unarchive_document` — wrapping IT Glue's `archived` boolean attribute.
- Both share a single handler that toggles the attribute via `PATCH /documents/:id` with the standard JSON:API resource shape. There is no dedicated `/archive` sub-endpoint per IT Glue API docs.
- Unblocks agentic flows that create test docs by giving them a built-in cleanup path. Previously, orphan `[TEST] ...` documents had to be archived by hand from the IT Glue web UI.

Two tools (rather than one with a flag) chosen for agent discoverability — `archive_document(document_id)` reads unambiguously without the LLM having to remember a default-true flag.

Closes the cleanup gap surfaced during the `create_document_section` validation work this morning (docs `23395216` and `23412689` are both pending manual archive).

## Test plan

- [x] `npm run build` clean
- [x] 113 unit tests pass, including new `it.each` block pinning PATCH URL + payload shape for both directions
- [ ] After merge + ACA refresh on `gwp-itglue`, run `archive_document` against doc `23395216` and `23412689` as live acceptance test
- [ ] Verify `get_document` returns `archived: true` after archive call
- [ ] Verify `unarchive_document` round-trip against one of those docs returns it to `archived: false`