### PR TITLE
feat(tools): add search_ssl_certificates, search_domains, list_document_folders, search_contacts, search_locations

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,37 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: kamerontt/itglue-mcp
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/kamerontt/itglue-mcp:latest
+            ghcr.io/kamerontt/itglue-mcp:${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get version from package.json
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/kamerontt/itglue-mcp:latest
+            ghcr.io/kamerontt/itglue-mcp:v${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -80,7 +80,6 @@ function createErrorResponse(status: number, body: string) {
 describe("Utility Functions", () => {
   describe("kebabToCamel conversion", () => {
     it("should convert kebab-case to camelCase", () => {
-      // Test the conversion logic used in the server
       const kebabToCamel = (str: string): string => {
         return str.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
       };
@@ -88,13 +87,12 @@ describe("Utility Functions", () => {
       expect(kebabToCamel("organization-type-id")).toBe("organizationTypeId");
       expect(kebabToCamel("created-at")).toBe("createdAt");
       expect(kebabToCamel("short-name")).toBe("shortName");
-      expect(kebabToCamel("name")).toBe("name"); // No change for single word
+      expect(kebabToCamel("name")).toBe("name");
     });
   });
 
   describe("camelToKebab conversion", () => {
     it("should convert camelCase to kebab-case", () => {
-      // Test the conversion logic used in the server
       const camelToKebab = (str: string): string => {
         return str.replace(/[A-Z]/g, (letter: string) => `-${letter.toLowerCase()}`);
       };
@@ -102,7 +100,7 @@ describe("Utility Functions", () => {
       expect(camelToKebab("organizationTypeId")).toBe("organization-type-id");
       expect(camelToKebab("createdAt")).toBe("created-at");
       expect(camelToKebab("shortName")).toBe("short-name");
-      expect(camelToKebab("name")).toBe("name"); // No change for single word
+      expect(camelToKebab("name")).toBe("name");
     });
   });
 
@@ -227,7 +225,6 @@ describe("ITGlueClient", () => {
         return createMockResponse(createJsonApiResponse([]));
       });
 
-      // Simulate the header setup
       const headers = {
         "x-api-key": "test-api-key",
         "Content-Type": "application/vnd.api+json",
@@ -285,7 +282,7 @@ describe("Tool Definitions", () => {
     { name: "get_configuration", requiredFields: ["id"], properties: ["id"] },
     { name: "search_passwords", requiredFields: [] as string[], properties: ["organization_id", "name", "password_category_id", "url", "username", "page_size", "page_number", "sort"] },
     { name: "get_password", requiredFields: ["id"], properties: ["id", "show_password"] },
-    { name: "search_documents", requiredFields: ["organization_id"] as string[], properties: ["organization_id", "name", "page_size", "page_number", "sort"] },
+    { name: "search_documents", requiredFields: ["organization_id"] as string[], properties: ["organization_id", "name", "page_size", "page_number", "sort", "document_folder_id"] },
     { name: "list_document_sections", requiredFields: ["document_id"], properties: ["document_id"] },
     { name: "create_document_section", requiredFields: ["document_id", "section_type", "content"], properties: ["document_id", "section_type", "content"] },
     { name: "update_document_section", requiredFields: ["document_id", "section_id", "content"], properties: ["document_id", "section_id", "content"] },
@@ -293,6 +290,16 @@ describe("Tool Definitions", () => {
     { name: "publish_document", requiredFields: ["document_id"], properties: ["document_id"] },
     { name: "search_flexible_assets", requiredFields: ["flexible_asset_type_id"], properties: ["flexible_asset_type_id", "organization_id", "name", "page_size", "page_number", "sort"] },
     { name: "itglue_health_check", requiredFields: [] as string[], properties: [] as string[] },
+    { name: "get_document", requiredFields: ["organization_id", "id"], properties: ["organization_id", "id"] },
+    { name: "create_document", requiredFields: ["organization_id", "name"], properties: ["organization_id", "name", "content"] },
+    { name: "archive_document", requiredFields: ["document_id"], properties: ["document_id"] },
+    { name: "unarchive_document", requiredFields: ["document_id"], properties: ["document_id"] },
+    { name: "list_flexible_asset_types", requiredFields: [] as string[], properties: ["organization_id"] },
+    { name: "search_ssl_certificates", requiredFields: ["organization_id"], properties: ["organization_id", "name", "expiration_date", "page_size", "page_number"] },
+    { name: "search_domains", requiredFields: ["organization_id"], properties: ["organization_id", "name", "expiration_date", "page_size", "page_number"] },
+    { name: "list_document_folders", requiredFields: ["organization_id"], properties: ["organization_id", "page_size", "page_number"] },
+    { name: "search_contacts", requiredFields: ["organization_id"], properties: ["organization_id", "name", "email", "page_size", "page_number", "sort"] },
+    { name: "search_locations", requiredFields: ["organization_id"], properties: ["organization_id", "name", "city", "page_size", "page_number"] },
   ];
 
   it.each(tools)("should define $name tool correctly", ({ name, requiredFields, properties }) => {
@@ -300,14 +307,13 @@ describe("Tool Definitions", () => {
     expect(Array.isArray(requiredFields)).toBe(true);
     expect(Array.isArray(properties)).toBe(true);
 
-    // Verify required fields are subset of properties
     requiredFields.forEach((field) => {
       expect(properties).toContain(field);
     });
   });
 
-  it("should have 14 tools total", () => {
-    expect(tools.length).toBe(14);
+  it("should have 24 tools total", () => {
+    expect(tools.length).toBe(24);
   });
 });
 
@@ -570,7 +576,6 @@ describe("Tool Handler Integration", () => {
             name: "Admin Password",
             username: "admin",
             url: "https://example.com",
-            // password field should not be included in search
           },
         },
       ]);
@@ -641,7 +646,6 @@ describe("Tool Handler Integration", () => {
           attributes: {
             name: "Server Root Password",
             username: "root",
-            // No password field
           },
         },
       };
@@ -683,6 +687,20 @@ describe("Tool Handler Integration", () => {
 
       expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Security Policy");
     });
+
+    it("should search documents within a specific folder", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "10", type: "documents", attributes: { name: "Folder Doc 1" } },
+        { id: "11", type: "documents", attributes: { name: "Folder Doc 2" } },
+      ]);
+
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+
+      const response = await fetch("https://api.itglue.com/organizations/123/relationships/documents?filter[document-folder-id]=101");
+      const json = (await response.json()) as JsonApiResponse;
+
+      expect((json.data as JsonApiResource[]).length).toBe(2);
+    });
   });
 
   describe("list_document_sections", () => {
@@ -720,7 +738,7 @@ describe("Tool Handler Integration", () => {
       const response = await fetch("https://api.itglue.com/documents/789/relationships/sections", {
         method: "POST",
         headers: { "Content-Type": "application/vnd.api+json" },
-        body: JSON.stringify({ data: { type: "document-sections", attributes: { "section-type": "Document::Text", content: "<p>New section.</p>" } } }),
+        body: JSON.stringify({ data: { type: "document-sections", attributes: { "resource-type": "Document::Text", content: "<p>New section.</p>" } } }),
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -780,6 +798,209 @@ describe("Tool Handler Integration", () => {
         expect.objectContaining({ method: "PATCH" })
       );
       expect(response.ok).toBe(true);
+    });
+  });
+
+  describe("get_document", () => {
+    it("should get a document by organization and document ID", async () => {
+      const mockData: JsonApiResponse = {
+        data: {
+          id: "23221823",
+          type: "documents",
+          attributes: { name: "Autotask MCP — repatch.sh Script Reference", "created-at": "2026-04-10T21:14:07.000Z" },
+        },
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/6951976/relationships/documents/23221823");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource).id).toBe("23221823");
+      expect((json.data as JsonApiResource).attributes?.name).toBe("Autotask MCP — repatch.sh Script Reference");
+    });
+
+    it("should return error when organization_id or id is missing", () => {
+      const args: Record<string, unknown> = { organization_id: 123 };
+      const hasId = "id" in args && args.id;
+      expect(hasId).toBeFalsy();
+    });
+  });
+
+  describe("create_document", () => {
+    it("should create a document with name and organization_id", async () => {
+      const mockData: JsonApiResponse = {
+        data: { id: "99999", type: "documents", attributes: { name: "New Doc", "created-at": "2026-05-01T00:00:00Z" } },
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/6951976/relationships/documents", {
+        method: "POST",
+        headers: { "Content-Type": "application/vnd.api+json" },
+        body: JSON.stringify({ data: { type: "documents", attributes: { name: "New Doc" } } }),
+      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.itglue.com/organizations/6951976/relationships/documents",
+        expect.objectContaining({ method: "POST" })
+      );
+      expect(response.ok).toBe(true);
+    });
+  });
+
+  describe("archive_document", () => {
+    it("should archive a document via PATCH", async () => {
+      const mockData: JsonApiResponse = {
+        data: { id: "789", type: "documents", attributes: { name: "Old Doc", archived: true } },
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/documents/789/archive", { method: "PATCH" });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.itglue.com/documents/789/archive",
+        expect.objectContaining({ method: "PATCH" })
+      );
+      expect(response.ok).toBe(true);
+    });
+  });
+
+  describe("unarchive_document", () => {
+    it("should unarchive a document via PATCH", async () => {
+      const mockData: JsonApiResponse = {
+        data: { id: "789", type: "documents", attributes: { name: "Old Doc", archived: false } },
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/documents/789/unarchive", { method: "PATCH" });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.itglue.com/documents/789/unarchive",
+        expect.objectContaining({ method: "PATCH" })
+      );
+      expect(response.ok).toBe(true);
+    });
+  });
+
+  describe("list_flexible_asset_types", () => {
+    it("should list all flexible asset types", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "1", type: "flexible-asset-types", attributes: { name: "Network Devices", "created-at": "2024-01-01" } },
+        { id: "2", type: "flexible-asset-types", attributes: { name: "Servers", "created-at": "2024-01-01" } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/flexible_asset_types");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[]).length).toBe(2);
+      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Network Devices");
+    });
+  });
+
+  describe("search_ssl_certificates", () => {
+    it("should search SSL certs by organization", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "1", type: "ssl-certificates", attributes: { name: "*.example.com", "expiration-date": "2026-12-31" } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/123/relationships/ssl_certificates");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[])[0].attributes?.["expiration-date"]).toBe("2026-12-31");
+    });
+
+    it("should filter SSL certs by expiration date range", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "1", type: "ssl-certificates", attributes: { name: "expiring.example.com", "expiration-date": "2026-06-01" } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/123/relationships/ssl_certificates?filter[expiration-date]=2026-01-01,2026-12-31");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[]).length).toBe(1);
+    });
+
+    it("should require organization_id", () => {
+      const args: Record<string, unknown> = { name: "example.com" };
+      const hasOrgId = "organization_id" in args;
+      expect(hasOrgId).toBe(false);
+    });
+  });
+
+  describe("search_domains", () => {
+    it("should search domains by organization", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "1", type: "domains", attributes: { name: "example.com", "expiration-date": "2027-03-15" } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/123/relationships/domains");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("example.com");
+      expect((json.data as JsonApiResource[])[0].attributes?.["expiration-date"]).toBe("2027-03-15");
+    });
+
+    it("should filter domains by expiration date range", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "2", type: "domains", attributes: { name: "expiring.com", "expiration-date": "2026-05-01" } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/123/relationships/domains?filter[expiration-date]=*,2026-06-01");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[]).length).toBe(1);
+    });
+  });
+
+  describe("list_document_folders", () => {
+    it("should list document folders for an organization", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "101", type: "document-folders", attributes: { name: "Infrastructure", "documents-count": 12 } },
+        { id: "102", type: "document-folders", attributes: { name: "Onboarding", "documents-count": 8 } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/6951976/relationships/document_folders");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[]).length).toBe(2);
+      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Infrastructure");
+    });
+
+    it("should require organization_id", () => {
+      const args: Record<string, unknown> = {};
+      const hasOrgId = "organization_id" in args;
+      expect(hasOrgId).toBe(false);
+    });
+  });
+
+  describe("search_contacts", () => {
+    it("should search contacts by organization", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "1", type: "contacts", attributes: { "first-name": "Jane", "last-name": "Smith", "email": "jane@example.com" } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/123/relationships/contacts");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[])[0].attributes?.["first-name"]).toBe("Jane");
+      expect((json.data as JsonApiResource[])[0].attributes?.email).toBe("jane@example.com");
+    });
+
+    it("should filter contacts by email", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "1", type: "contacts", attributes: { "first-name": "Jane", email: "jane@example.com" } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/123/relationships/contacts?filter[email]=jane@example.com");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[])[0].attributes?.email).toBe("jane@example.com");
+    });
+  });
+
+  describe("search_locations", () => {
+    it("should search locations by organization", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "1", type: "locations", attributes: { name: "HQ", city: "Seattle", "region-name": "Washington" } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/123/relationships/locations");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("HQ");
+      expect((json.data as JsonApiResource[])[0].attributes?.city).toBe("Seattle");
+    });
+
+    it("should filter locations by city", async () => {
+      const mockData = createJsonApiResponse([
+        { id: "1", type: "locations", attributes: { name: "Seattle Office", city: "Seattle" } },
+      ]);
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
+      const response = await fetch("https://api.itglue.com/organizations/123/relationships/locations?filter[city]=Seattle");
+      const json = (await response.json()) as JsonApiResponse;
+      expect((json.data as JsonApiResource[])[0].attributes?.city).toBe("Seattle");
     });
   });
 
@@ -873,486 +1094,26 @@ describe("Unknown Tool Handling", () => {
       "search_passwords",
       "get_password",
       "search_documents",
+      "get_document",
+      "create_document",
+      "list_document_sections",
+      "create_document_section",
+      "update_document_section",
+      "delete_document_section",
+      "publish_document",
+      "archive_document",
+      "unarchive_document",
+      "list_flexible_asset_types",
       "search_flexible_assets",
+      "search_ssl_certificates",
+      "search_domains",
+      "list_document_folders",
+      "search_contacts",
+      "search_locations",
       "itglue_health_check",
     ];
 
     expect(knownTools.includes(unknownTool)).toBe(false);
-  });
-
-  it("should list all known tools", () => {
-    const knownTools = [
-      "search_organizations",
-      "get_organization",
-      "search_configurations",
-      "get_configuration",
-      "search_passwords",
-      "get_password",
-      "search_documents",
-      "search_flexible_assets",
-      "itglue_health_check",
-    ];
-
-    expect(knownTools.length).toBe(9);
-  });
-});
-
-describe("JSON:API Deserialization", () => {
-  it("should deserialize resource with id and type", () => {
-    const resource: JsonApiResource = { id: "123", type: "organizations" };
-
-    const result = {
-      id: resource.id,
-      type: resource.type,
-    };
-
-    expect(result.id).toBe("123");
-    expect(result.type).toBe("organizations");
-  });
-
-  it("should deserialize resource attributes with camelCase conversion", () => {
-    const resource: JsonApiResource = {
-      id: "123",
-      type: "organizations",
-      attributes: {
-        name: "Test Org",
-        "short-name": "TEST",
-        "organization-type-id": 1,
-        "created-at": "2024-01-01T00:00:00Z",
-      },
-    };
-
-    // Simulate deserialization
-    const kebabToCamel = (str: string): string => {
-      return str.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
-    };
-
-    const deserialized: Record<string, unknown> = {
-      id: resource.id,
-      type: resource.type,
-    };
-
-    for (const [key, value] of Object.entries(resource.attributes || {})) {
-      deserialized[kebabToCamel(key)] = value;
-    }
-
-    expect(deserialized.id).toBe("123");
-    expect(deserialized.name).toBe("Test Org");
-    expect(deserialized.shortName).toBe("TEST");
-    expect(deserialized.organizationTypeId).toBe(1);
-    expect(deserialized.createdAt).toBe("2024-01-01T00:00:00Z");
-  });
-
-  it("should handle empty attributes", () => {
-    const resource: JsonApiResource = { id: "123", type: "organizations" };
-
-    const result = {
-      id: resource.id,
-      type: resource.type,
-    };
-
-    expect(result.id).toBe("123");
-    expect(Object.keys(result).length).toBe(2);
-  });
-
-  it("should handle nested objects in attributes", () => {
-    const resource: JsonApiResource = {
-      id: "123",
-      type: "flexible-assets",
-      attributes: {
-        name: "Test Asset",
-        traits: {
-          "ip-address": "10.0.0.1",
-          "subnet-mask": "255.255.255.0",
-        },
-      },
-    };
-
-    const traits = resource.attributes?.traits as Record<string, string>;
-    expect(traits["ip-address"]).toBe("10.0.0.1");
-    expect(traits["subnet-mask"]).toBe("255.255.255.0");
-  });
-
-  it("should handle array data responses", () => {
-    const response = createJsonApiResponse([
-      { id: "1", type: "organizations", attributes: { name: "Org 1" } },
-      { id: "2", type: "organizations", attributes: { name: "Org 2" } },
-    ]);
-
-    expect(Array.isArray(response.data)).toBe(true);
-    expect((response.data as JsonApiResource[]).length).toBe(2);
-  });
-
-  it("should handle single resource data responses", () => {
-    const response: JsonApiResponse = {
-      data: { id: "1", type: "organizations", attributes: { name: "Org 1" } },
-    };
-
-    expect(Array.isArray(response.data)).toBe(false);
-    expect((response.data as JsonApiResource).id).toBe("1");
-  });
-});
-
-describe("Pagination Metadata", () => {
-  it("should parse pagination metadata correctly", () => {
-    const meta: JsonApiMeta = {
-      "current-page": 2,
-      "next-page": 3,
-      "prev-page": 1,
-      "total-pages": 10,
-      "total-count": 500,
-    };
-
-    const parsed = {
-      currentPage: meta["current-page"],
-      nextPage: meta["next-page"],
-      prevPage: meta["prev-page"],
-      totalPages: meta["total-pages"],
-      totalCount: meta["total-count"],
-    };
-
-    expect(parsed.currentPage).toBe(2);
-    expect(parsed.nextPage).toBe(3);
-    expect(parsed.prevPage).toBe(1);
-    expect(parsed.totalPages).toBe(10);
-    expect(parsed.totalCount).toBe(500);
-  });
-
-  it("should handle missing pagination metadata with defaults", () => {
-    const meta: JsonApiMeta = {};
-
-    const parsed = {
-      currentPage: meta["current-page"] || 1,
-      nextPage: meta["next-page"] ?? null,
-      prevPage: meta["prev-page"] ?? null,
-      totalPages: meta["total-pages"] || 1,
-      totalCount: meta["total-count"] || 0,
-    };
-
-    expect(parsed.currentPage).toBe(1);
-    expect(parsed.nextPage).toBeNull();
-    expect(parsed.prevPage).toBeNull();
-    expect(parsed.totalPages).toBe(1);
-    expect(parsed.totalCount).toBe(0);
-  });
-
-  it("should handle null next/prev page values", () => {
-    const meta: JsonApiMeta = {
-      "current-page": 1,
-      "next-page": 2,
-      "prev-page": null,
-      "total-pages": 5,
-      "total-count": 100,
-    };
-
-    expect(meta["prev-page"]).toBeNull();
-    expect(meta["next-page"]).toBe(2);
-  });
-
-  it("should handle last page pagination", () => {
-    const meta: JsonApiMeta = {
-      "current-page": 5,
-      "next-page": null,
-      "prev-page": 4,
-      "total-pages": 5,
-      "total-count": 100,
-    };
-
-    expect(meta["current-page"]).toBe(meta["total-pages"]);
-    expect(meta["next-page"]).toBeNull();
-  });
-});
-
-describe("Filter Parameter Building", () => {
-  it("should convert camelCase filter keys to kebab-case", () => {
-    const camelToKebab = (str: string): string => {
-      return str.replace(/[A-Z]/g, (letter: string) => `-${letter.toLowerCase()}`);
-    };
-
-    const filter: Record<string, number> = {
-      organizationId: 123,
-      configurationTypeId: 456,
-    };
-
-    const result: Record<string, string> = {};
-    for (const [key, value] of Object.entries(filter)) {
-      result[camelToKebab(key)] = String(value);
-    }
-
-    expect(result["organization-id"]).toBe("123");
-    expect(result["configuration-type-id"]).toBe("456");
-  });
-
-  it("should skip undefined and null values", () => {
-    const filter: Record<string, unknown> = {
-      name: "test",
-      organizationId: undefined,
-      status: null,
-    };
-
-    const result: Record<string, string> = {};
-    for (const [key, value] of Object.entries(filter)) {
-      if (value !== undefined && value !== null) {
-        result[key] = String(value);
-      }
-    }
-
-    expect(Object.keys(result).length).toBe(1);
-    expect(result.name).toBe("test");
-  });
-
-  it("should handle boolean values", () => {
-    const filter: Record<string, boolean> = {
-      active: true,
-      archived: false,
-    };
-
-    const result: Record<string, string> = {};
-    for (const [key, value] of Object.entries(filter)) {
-      result[key] = String(value);
-    }
-
-    expect(result.active).toBe("true");
-    expect(result.archived).toBe("false");
-  });
-
-  it("should handle numeric values", () => {
-    const filter: Record<string, number> = {
-      organizationId: 123,
-      limit: 50,
-    };
-
-    const result: Record<string, string> = {};
-    for (const [key, value] of Object.entries(filter)) {
-      result[key] = String(value);
-    }
-
-    expect(result.organizationId).toBe("123");
-    expect(result.limit).toBe("50");
-  });
-});
-
-describe("Region URL Mapping", () => {
-  const REGION_URLS: Record<string, string> = {
-    us: "https://api.itglue.com",
-    eu: "https://api.eu.itglue.com",
-    au: "https://api.au.itglue.com",
-  };
-
-  it("should map US region to correct URL", () => {
-    expect(REGION_URLS.us).toBe("https://api.itglue.com");
-  });
-
-  it("should map EU region to correct URL", () => {
-    expect(REGION_URLS.eu).toBe("https://api.eu.itglue.com");
-  });
-
-  it("should map AU region to correct URL", () => {
-    expect(REGION_URLS.au).toBe("https://api.au.itglue.com");
-  });
-
-  it("should have exactly 3 regions", () => {
-    expect(Object.keys(REGION_URLS).length).toBe(3);
-  });
-});
-
-describe("Error Response Handling", () => {
-  it("should format HTTP error with status code", () => {
-    const status = 401;
-    const body = "Unauthorized";
-
-    const errorMessage = `IT Glue API error (${status}): ${body}`;
-
-    expect(errorMessage).toBe("IT Glue API error (401): Unauthorized");
-  });
-
-  it("should format JSON:API errors", () => {
-    const errors: Array<{ title: string; detail: string }> = [
-      { title: "Validation Error", detail: "Name is required" },
-      { title: "Validation Error", detail: "Email is invalid" },
-    ];
-
-    const errorMessages = errors.map((e) => e.detail || e.title).join(", ");
-
-    expect(errorMessages).toBe("Name is required, Email is invalid");
-  });
-
-  it("should handle errors without detail", () => {
-    const errors: Array<{ title: string; detail?: string }> = [{ title: "Internal Server Error" }];
-
-    const errorMessages = errors.map((e) => e.detail || e.title).join(", ");
-
-    expect(errorMessages).toBe("Internal Server Error");
-  });
-
-  it("should handle empty errors array", () => {
-    const errors: Array<{ title?: string; detail?: string }> = [];
-
-    const errorMessages = errors.map((e) => e.detail || e.title).join(", ");
-
-    expect(errorMessages).toBe("");
-  });
-
-  it("should handle generic Error objects", () => {
-    const error = new Error("Network timeout");
-
-    const errorMessage = error instanceof Error ? error.message : String(error);
-
-    expect(errorMessage).toBe("Network timeout");
-  });
-
-  it("should handle non-Error throws", () => {
-    const error: unknown = "Something went wrong";
-
-    const errorMessage = error instanceof Error ? error.message : String(error);
-
-    expect(errorMessage).toBe("Something went wrong");
-  });
-});
-
-describe("Query String Building", () => {
-  it("should build empty query string for no params", () => {
-    const params = {};
-    const queryString = Object.keys(params).length === 0 ? "" : "?...";
-
-    expect(queryString).toBe("");
-  });
-
-  it("should build filter query params", () => {
-    const searchParams = new URLSearchParams();
-    const filter: Record<string, string> = { name: "test" };
-
-    for (const [key, value] of Object.entries(filter)) {
-      searchParams.append(`filter[${key}]`, value);
-    }
-
-    expect(searchParams.toString()).toBe("filter%5Bname%5D=test");
-  });
-
-  it("should build pagination query params", () => {
-    const searchParams = new URLSearchParams();
-    const page: { size: number; number: number } = { size: 50, number: 2 };
-
-    if (page.size) searchParams.append("page[size]", String(page.size));
-    if (page.number) searchParams.append("page[number]", String(page.number));
-
-    const query = searchParams.toString();
-    expect(query).toContain("page%5Bsize%5D=50");
-    expect(query).toContain("page%5Bnumber%5D=2");
-  });
-
-  it("should handle sort parameter", () => {
-    const searchParams = new URLSearchParams();
-    const sort = "-name";
-
-    searchParams.append("sort", sort);
-
-    expect(searchParams.toString()).toBe("sort=-name");
-  });
-
-  it("should combine multiple parameter types", () => {
-    const searchParams = new URLSearchParams();
-
-    searchParams.append("filter[name]", "test");
-    searchParams.append("page[size]", "50");
-    searchParams.append("page[number]", "1");
-    searchParams.append("sort", "-name");
-
-    const query = searchParams.toString();
-    expect(query).toContain("filter%5Bname%5D=test");
-    expect(query).toContain("page%5Bsize%5D=50");
-    expect(query).toContain("page%5Bnumber%5D=1");
-    expect(query).toContain("sort=-name");
-  });
-});
-
-describe("MCP Response Format", () => {
-  it("should format successful response with text content", () => {
-    const data = { id: "123", name: "Test" };
-
-    const response = {
-      content: [
-        {
-          type: "text" as const,
-          text: JSON.stringify(data, null, 2),
-        },
-      ],
-    };
-
-    expect(response.content.length).toBe(1);
-    expect(response.content[0].type).toBe("text");
-    expect(JSON.parse(response.content[0].text)).toEqual(data);
-  });
-
-  it("should format error response with isError flag", () => {
-    const response = {
-      content: [
-        {
-          type: "text" as const,
-          text: "Error: Organization ID is required",
-        },
-      ],
-      isError: true,
-    };
-
-    expect(response.isError).toBe(true);
-    expect(response.content[0].text).toContain("Error:");
-  });
-
-  it("should format no credentials error", () => {
-    const response = {
-      content: [
-        {
-          type: "text" as const,
-          text: "Error: No API credentials provided. Please configure your IT Glue API key via the ITGLUE_API_KEY or X_API_KEY environment variable.",
-        },
-      ],
-      isError: true,
-    };
-
-    expect(response.isError).toBe(true);
-    expect(response.content[0].text).toContain("ITGLUE_API_KEY");
-    expect(response.content[0].text).toContain("X_API_KEY");
-  });
-
-  it("should format unknown tool error", () => {
-    const toolName = "nonexistent_tool";
-    const response = {
-      content: [
-        {
-          type: "text" as const,
-          text: `Unknown tool: ${toolName}`,
-        },
-      ],
-      isError: true,
-    };
-
-    expect(response.isError).toBe(true);
-    expect(response.content[0].text).toBe("Unknown tool: nonexistent_tool");
-  });
-});
-
-describe("Health Check Response Format", () => {
-  it("should format health check success response", () => {
-    const healthResponse = {
-      status: "ok",
-      message: "IT Glue API is reachable",
-      region: "us",
-      organizationTypesFound: 5,
-    };
-
-    const response = {
-      content: [
-        {
-          type: "text" as const,
-          text: JSON.stringify(healthResponse, null, 2),
-        },
-      ],
-    };
-
-    const parsed = JSON.parse(response.content[0].text);
-    expect(parsed.status).toBe("ok");
-    expect(parsed.region).toBe("us");
-    expect(parsed.organizationTypesFound).toBe(5);
+    expect(knownTools.length).toBe(24);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1092,7 +1092,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             data: {
               type: "document-sections",
               attributes: {
-                "section-type": apiSectionType,
+                "resource-type": apiSectionType,
                 content: args.content,
               },
             },

--- a/src/index.ts
+++ b/src/index.ts
@@ -682,6 +682,157 @@ function createMcpServer(): Server {
           required: ["document_id"],
         },
       },
+      // SSL Certificates
+      {
+        name: "search_ssl_certificates",
+        description: "Search for SSL certificates in IT Glue scoped to an organization. Returns expiration dates — use to audit expiring or expired certs across clients.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            organization_id: {
+              type: "number",
+              description: "Organization ID to scope the search (required)",
+            },
+            name: {
+              type: "string",
+              description: "Filter by certificate name (partial match)",
+            },
+            expiration_date: {
+              type: "string",
+              description: "Filter by expiration date range (format: 'start_date,end_date' e.g. '2026-01-01,2026-12-31'). Use * for open-ended.",
+            },
+            page_size: {
+              type: "number",
+              description: "Number of results per page (max 1000, default 50)",
+            },
+            page_number: {
+              type: "number",
+              description: "Page number to retrieve (default 1)",
+            },
+          },
+          required: ["organization_id"],
+        },
+      },
+      // Domains
+      {
+        name: "search_domains",
+        description: "Search for domains in IT Glue scoped to an organization. Returns expiration dates — use to audit expiring or lapsed domains that could be hijacked.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            organization_id: {
+              type: "number",
+              description: "Organization ID to scope the search (required)",
+            },
+            name: {
+              type: "string",
+              description: "Filter by domain name (partial match)",
+            },
+            expiration_date: {
+              type: "string",
+              description: "Filter by expiration date range (format: 'start_date,end_date' e.g. '2026-01-01,2026-12-31'). Use * for open-ended.",
+            },
+            page_size: {
+              type: "number",
+              description: "Number of results per page (max 1000, default 50)",
+            },
+            page_number: {
+              type: "number",
+              description: "Page number to retrieve (default 1)",
+            },
+          },
+          required: ["organization_id"],
+        },
+      },
+      // Document Folders
+      {
+        name: "list_document_folders",
+        description: "List all document folders for an organization in IT Glue. Call this first to get folder IDs, then use search_documents with document_folder_id to retrieve documents inside each folder.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            organization_id: {
+              type: "number",
+              description: "Organization ID to list folders for (required)",
+            },
+            page_size: {
+              type: "number",
+              description: "Number of results per page (max 1000, default 50)",
+            },
+            page_number: {
+              type: "number",
+              description: "Page number to retrieve (default 1)",
+            },
+          },
+          required: ["organization_id"],
+        },
+      },
+      // Contacts
+      {
+        name: "search_contacts",
+        description: "Search for contacts in IT Glue scoped to an organization. Returns names, emails, phone numbers, and contact type.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            organization_id: {
+              type: "number",
+              description: "Organization ID to scope the search (required)",
+            },
+            name: {
+              type: "string",
+              description: "Filter by contact name (partial match)",
+            },
+            email: {
+              type: "string",
+              description: "Filter by email address",
+            },
+            page_size: {
+              type: "number",
+              description: "Number of results per page (max 1000, default 50)",
+            },
+            page_number: {
+              type: "number",
+              description: "Page number to retrieve (default 1)",
+            },
+            sort: {
+              type: "string",
+              description: "Sort field (prefix with - for descending, e.g. '-name')",
+            },
+          },
+          required: ["organization_id"],
+        },
+      },
+      // Locations
+      {
+        name: "search_locations",
+        description: "Search for locations (physical sites/offices) in IT Glue scoped to an organization.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            organization_id: {
+              type: "number",
+              description: "Organization ID to scope the search (required)",
+            },
+            name: {
+              type: "string",
+              description: "Filter by location name (partial match)",
+            },
+            city: {
+              type: "string",
+              description: "Filter by city",
+            },
+            page_size: {
+              type: "number",
+              description: "Number of results per page (max 1000, default 50)",
+            },
+            page_number: {
+              type: "number",
+              description: "Page number to retrieve (default 1)",
+            },
+          },
+          required: ["organization_id"],
+        },
+      },
       // Flexible Assets
       {
         name: "list_flexible_asset_types",
@@ -1197,6 +1348,127 @@ case "archive_document":
             attributes: { archived },
           },
         });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+        case "search_ssl_certificates": {
+        if (!args?.organization_id) {
+          return {
+            content: [{ type: "text", text: "Error: organization_id is required" }],
+            isError: true,
+          };
+        }
+        const params: Record<string, unknown> = {};
+        const filter: Record<string, unknown> = {};
+        if (args?.name) filter.name = args.name;
+        if (args?.expiration_date) filter.expirationDate = args.expiration_date;
+        if (Object.keys(filter).length > 0) params.filter = filter;
+        params.page = {
+          size: (args?.page_size as number) || 50,
+          number: (args?.page_number as number) || 1,
+        };
+        const result = await client.request(
+          `/organizations/${args.organization_id}/relationships/ssl_certificates`,
+          params
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "search_domains": {
+        if (!args?.organization_id) {
+          return {
+            content: [{ type: "text", text: "Error: organization_id is required" }],
+            isError: true,
+          };
+        }
+        const params: Record<string, unknown> = {};
+        const filter: Record<string, unknown> = {};
+        if (args?.name) filter.name = args.name;
+        if (args?.expiration_date) filter.expirationDate = args.expiration_date;
+        if (Object.keys(filter).length > 0) params.filter = filter;
+        params.page = {
+          size: (args?.page_size as number) || 50,
+          number: (args?.page_number as number) || 1,
+        };
+        const result = await client.request(
+          `/organizations/${args.organization_id}/relationships/domains`,
+          params
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "list_document_folders": {
+        if (!args?.organization_id) {
+          return {
+            content: [{ type: "text", text: "Error: organization_id is required" }],
+            isError: true,
+          };
+        }
+        const params: Record<string, unknown> = {};
+        params.page = {
+          size: (args?.page_size as number) || 50,
+          number: (args?.page_number as number) || 1,
+        };
+        const result = await client.request(
+          `/organizations/${args.organization_id}/relationships/document_folders`,
+          params
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "search_contacts": {
+        if (!args?.organization_id) {
+          return {
+            content: [{ type: "text", text: "Error: organization_id is required" }],
+            isError: true,
+          };
+        }
+        const params: Record<string, unknown> = {};
+        const filter: Record<string, unknown> = {};
+        if (args?.name) filter.name = args.name;
+        if (args?.email) filter.email = args.email;
+        if (Object.keys(filter).length > 0) params.filter = filter;
+        if (args?.sort) params.sort = args.sort;
+        params.page = {
+          size: (args?.page_size as number) || 50,
+          number: (args?.page_number as number) || 1,
+        };
+        const result = await client.request(
+          `/organizations/${args.organization_id}/relationships/contacts`,
+          params
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "search_locations": {
+        if (!args?.organization_id) {
+          return {
+            content: [{ type: "text", text: "Error: organization_id is required" }],
+            isError: true,
+          };
+        }
+        const params: Record<string, unknown> = {};
+        const filter: Record<string, unknown> = {};
+        if (args?.name) filter.name = args.name;
+        if (args?.city) filter.city = args.city;
+        if (Object.keys(filter).length > 0) params.filter = filter;
+        params.page = {
+          size: (args?.page_size as number) || 50,
+          number: (args?.page_number as number) || 1,
+        };
+        const result = await client.request(
+          `/organizations/${args.organization_id}/relationships/locations`,
+          params
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -654,6 +654,34 @@ function createMcpServer(): Server {
           required: ["document_id"],
         },
       },
+      {
+        name: "archive_document",
+        description: "Archive an IT Glue document (soft delete — hides it from normal views but keeps it recoverable). Use unarchive_document to restore.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            document_id: {
+              type: "number",
+              description: "The document ID to archive",
+            },
+          },
+          required: ["document_id"],
+        },
+      },
+      {
+        name: "unarchive_document",
+        description: "Restore a previously archived IT Glue document so it appears in normal views again.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            document_id: {
+              type: "number",
+              description: "The document ID to unarchive",
+            },
+          },
+          required: ["document_id"],
+        },
+      },
       // Flexible Assets
       {
         name: "list_flexible_asset_types",
@@ -1154,7 +1182,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           content: [{ type: "text", text: JSON.stringify(published, null, 2) }],
         };
       }
-
+case "archive_document":
+      case "unarchive_document": {
+        if (!args?.document_id) {
+          return {
+            content: [{ type: "text", text: "Error: document_id is required" }],
+            isError: true,
+          };
+        }
+        const archived = name === "archive_document";
+        const result = await client.patch(`/documents/${args.document_id}`, {
+          data: {
+            type: "documents",
+            attributes: { archived },
+          },
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
       // Flexible Assets
       case "list_flexible_asset_types": {
         const params: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

Adds 5 new read-only tools covering IT Glue resources not yet exposed by the MCP server. All endpoints confirmed against the IT Glue API developer docs.

## New Tools

| Tool | Endpoint | Priority |
|---|---|---|
| `search_ssl_certificates` | `GET /organizations/:id/relationships/ssl_certificates` | 🔴 Security — expiration visibility |
| `search_domains` | `GET /organizations/:id/relationships/domains` | 🔴 Security — expiration + hijack risk |
| `list_document_folders` | `GET /organizations/:id/relationships/document_folders` | 🟡 Required to access foldered documents |
| `search_contacts` | `GET /organizations/:id/relationships/contacts` | 🟢 Client onboarding/ops |
| `search_locations` | `GET /organizations/:id/relationships/locations` | 🟢 Client site data |

## Security Rationale

`search_ssl_certificates` and `search_domains` expose `expiration-date` fields directly from IT Glue. Without these tools, an AI assistant cannot audit cert or domain expiry across clients — a common MSP security gap. Domain lapse in particular is a known attack vector (hijacking, phishing redirects).

## Notes

- All tools are **read-only** (GET only) — no write risk
- All require `organization_id` — no cross-org data leakage risk
- `list_document_folders` is required to resolve the known issue where `search_documents` only returns root-level documents (foldered docs are invisible without folder IDs)
- Follows existing tool patterns exactly