### PR TITLE
Add destructive-action warnings to mutating tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
       - run: npm ci
       - run: npm run lint
         continue-on-error: true
+      - name: Lint destructive tool warnings
+        run: node scripts/lint-destructive-warnings.mjs src
       - run: npm run build
       - run: npm test
 

--- a/scripts/lint-destructive-warnings.mjs
+++ b/scripts/lint-destructive-warnings.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Lint MCP tool definitions for missing destructive-action warnings.
+// Usage: node scripts/lint-destructive-warnings.mjs [path ...]
+// Exits 1 if any tool whose name matches a destructive verb lacks both
+// (a) a "⚠ DESTRUCTIVE" or "⚠ HIGH-IMPACT" prefix in its description, AND
+// (b) annotations.destructiveHint: true.
+//
+// Convention: see ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md §2.7b.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const DESTRUCTIVE_VERBS = [
+  'delete', 'remove', 'destroy', 'wipe', 'purge', 'drop',
+  'disable', 'deactivate', 'suspend',
+  'revoke', 'reset_password', 'reset_mfa',
+  'offboard', 'terminate',
+  'archive', 'unarchive',
+  'quarantine_delete', 'quarantine_release',
+];
+
+const SKIP_PATTERNS = [
+  /_dropdown\b/, /_list\b/, /_search\b/, /_get\b/,
+  /quarantine_list/, /quarantine_search/,
+  /messages_blocked/, /clicks_blocked/,
+];
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', '__tests__', '.git', 'docs', 'docs-repo']);
+
+function* walk(dir) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return; }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      yield* walk(full);
+    } else if (
+      entry.endsWith('.ts') &&
+      !entry.endsWith('.d.ts') &&
+      !entry.endsWith('.test.ts')
+    ) {
+      yield full;
+    }
+  }
+}
+
+const roots = process.argv.slice(2);
+if (roots.length === 0) roots.push('.');
+
+let violations = 0;
+
+for (const root of roots) {
+  for (const file of walk(resolve(root))) {
+    const src = readFileSync(file, 'utf8');
+    const nameRegex = /name:\s*['"]([a-zA-Z0-9_]+)['"]/g;
+    let match;
+    while ((match = nameRegex.exec(src)) !== null) {
+      const toolName = match[1];
+      const lower = toolName.toLowerCase();
+
+      if (SKIP_PATTERNS.some(p => p.test(lower))) continue;
+      if (!DESTRUCTIVE_VERBS.some(v => lower.includes(v))) continue;
+
+      const window = src.slice(match.index, match.index + 1200);
+      const hasWarningPrefix = /⚠\s*(DESTRUCTIVE|HIGH-IMPACT)/.test(window);
+      const hasDestructiveHint = /destructiveHint\s*:\s*true/.test(window);
+
+      if (!hasWarningPrefix || !hasDestructiveHint) {
+        violations++;
+        const lineNum = src.slice(0, match.index).split('\n').length;
+        const missing = [
+          !hasWarningPrefix && 'description prefix (⚠ DESTRUCTIVE/HIGH-IMPACT)',
+          !hasDestructiveHint && 'annotations.destructiveHint: true',
+        ].filter(Boolean).join(' + ');
+        console.error(`${file}:${lineNum}  ${toolName}  missing: ${missing}`);
+      }
+    }
+  }
+}
+
+if (violations > 0) {
+  console.error(`\n${violations} destructive tool(s) missing warnings.`);
+  console.error('See ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md §2.7b for the convention.');
+  process.exit(1);
+}
+console.log('All destructive tools carry the required warnings.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -681,7 +681,17 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
       },
       {
         name: "delete_document_section",
-        description: "Delete a section from an IT Glue document. Call publish_document after editing.",
+        description:
+          "⚠ DESTRUCTIVE — IRREVERSIBLE. Permanently deletes a section from an IT Glue document. " +
+          "This action cannot be undone. Call publish_document after editing. " +
+          "Confirm with the user before invoking.",
+        annotations: {
+          title: "Delete document section (irreversible)",
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
         inputSchema: {
           type: "object",
           properties: {
@@ -713,7 +723,17 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
       },
       {
         name: "archive_document",
-        description: "Archive an IT Glue document (soft delete — hides it from normal views but keeps it recoverable). Use unarchive_document to restore.",
+        description:
+          "⚠ HIGH-IMPACT. Archives an IT Glue document (soft delete — hides it from normal views " +
+          "but keeps it recoverable). Use unarchive_document to restore. " +
+          "Confirm with the user before invoking.",
+        annotations: {
+          title: "Archive document (reversible)",
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
         inputSchema: {
           type: "object",
           properties: {
@@ -727,7 +747,17 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
       },
       {
         name: "unarchive_document",
-        description: "Restore a previously archived IT Glue document so it appears in normal views again.",
+        description:
+          "⚠ HIGH-IMPACT. Restores a previously archived IT Glue document so it appears in " +
+          "normal views again. This makes the document visible to all users. " +
+          "Confirm with the user before invoking.",
+        annotations: {
+          title: "Unarchive document (reversible)",
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
         inputSchema: {
           type: "object",
           properties: {


### PR DESCRIPTION
## Summary

Adds destructive-action warnings to all mutating tools per the Wyre MCP convention (`⚠ DESTRUCTIVE` / `⚠ HIGH-IMPACT` description prefix + `annotations.destructiveHint: true`), plus a CI lint to enforce it going forward.

## Affected tools

- `delete_document_section`
- `archive_document`
- `unarchive_document`

## Convention

See `~/.claude/skills/mcp-vendor-scaffolding/SKILL.md` §2.7b.

## CI

`scripts/lint-destructive-warnings.mjs` is invoked from `.github/workflows/release.yml` immediately after the existing `npm run lint` step. Fails the job if any tool whose name contains a destructive verb lacks both the description prefix and the `destructiveHint` annotation.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `node scripts/lint-destructive-warnings.mjs src` passes
- [ ] CI green on PR