### PR TITLE
feat(tools): URL/ID-based folder selection for create_document

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      packages: write
     outputs:
       version: ${{ steps.release-version.outputs.version }}
       released: ${{ steps.release-version.outputs.released }}
@@ -104,16 +105,6 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
-      - name: Resolve release version
-        id: version
-        env:
-          RELEASE_VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          if [ -z "$RELEASE_VERSION" ]; then
-            echo "ERROR: needs.release.outputs.version is empty" >&2
-            exit 1
-          fi
-          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
@@ -122,7 +113,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:v${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}:v${{ needs.release.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -135,7 +126,7 @@ jobs:
           BUNDLE_NAME=$(node -p "require('./package.json').name.replace(/^@.*\\//, '')")
           npm install -g @anthropic-ai/mcpb
           npm run pack:mcpb
-          gh release upload "v${{ steps.version.outputs.version }}" "${BUNDLE_NAME}.mcpb" \
+          gh release upload "v${{ needs.release.outputs.version }}" "${BUNDLE_NAME}.mcpb" \
             --repo ${{ github.repository }} --clobber
 
       - name: Discord release notification
@@ -144,7 +135,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ needs.release.outputs.version }}"
           BODY=$(gh release view "v$VERSION" --json body --jq '.body' 2>/dev/null || echo "")
           SUMMARY=$(echo "$BODY" | sed '1,2d' | head -30 | cut -c1-1800)
           DESC="**${{ github.repository }}** — [v${VERSION}](https://github.com/${{ github.repository }}/releases/tag/v${VERSION})"$'\n'"${SUMMARY}"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -19,7 +19,11 @@ vi.stubGlobal("fetch", mockFetch);
 // Importing from ../index pulls in the production helpers. The module guards
 // its main() bootstrap on NODE_ENV=test so this import does not start an MCP
 // server during tests.
-import { createDocumentWithContent, ITGlueClient } from "../index.js";
+import {
+  buildFolderPickerOptions,
+  createDocumentWithContent,
+  ITGlueClient,
+} from "../index.js";
 
 // Store original env vars
 const originalEnv = { ...process.env };
@@ -771,6 +775,52 @@ describe("Tool Handler Integration", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
+    it("includes document_folder_id on the POST attributes when provided", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({
+        data: { id: "789", type: "documents", attributes: { name: "Doc" } },
+      }));
+
+      await createDocumentWithContent(newClient(), {
+        organization_id: 1765329,
+        name: "Doc",
+        document_folder_id: 42,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.data.attributes.document_folder_id).toBe(42);
+      expect(body.data.attributes.name).toBe("Doc");
+    });
+
+    it("accepts string folder ids and passes them through unchanged", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({
+        data: { id: "789", type: "documents", attributes: { name: "Doc" } },
+      }));
+
+      await createDocumentWithContent(newClient(), {
+        organization_id: 1765329,
+        name: "Doc",
+        document_folder_id: "42",
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.data.attributes.document_folder_id).toBe("42");
+    });
+
+    it("omits document_folder_id from attributes when not provided", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({
+        data: { id: "789", type: "documents", attributes: { name: "Doc" } },
+      }));
+
+      await createDocumentWithContent(newClient(), {
+        organization_id: 1765329,
+        name: "Doc",
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.data.attributes).not.toHaveProperty("document_folder_id");
+    });
+
     it("returns the document (not the section) as the caller-visible result", async () => {
       mockFetch
         .mockResolvedValueOnce(createMockResponse({
@@ -788,6 +838,100 @@ describe("Tool Handler Integration", () => {
 
       expect((result as { id: string; type: string }).id).toBe("23350960");
       expect((result as { id: string; type: string }).type).toBe("documents");
+    });
+  });
+
+  describe("buildFolderPickerOptions", () => {
+    it("always prepends a __root__ sentinel even when the folder list is empty", () => {
+      const options = buildFolderPickerOptions([]);
+      expect(options).toEqual([
+        { value: "__root__", label: "(Root — no folder)" },
+      ]);
+    });
+
+    it("builds breadcrumb labels for nested folders using parent-id (kebab-case)", () => {
+      const options = buildFolderPickerOptions([
+        { id: "1", attributes: { name: "Networking" } },
+        { id: "2", attributes: { name: "Firewalls", "parent-id": "1" } },
+        { id: "3", attributes: { name: "Edge", "parent-id": "2" } },
+      ]);
+      // First entry is the sentinel; the rest are sorted by label.
+      expect(options[0]).toEqual({ value: "__root__", label: "(Root — no folder)" });
+      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
+      expect(byValue["1"]).toBe("Networking");
+      expect(byValue["2"]).toBe("Networking / Firewalls");
+      expect(byValue["3"]).toBe("Networking / Firewalls / Edge");
+    });
+
+    it("also accepts snake_case parent_id (for proxied/cached responses)", () => {
+      const options = buildFolderPickerOptions([
+        { id: "1", attributes: { name: "Top" } },
+        { id: "2", attributes: { name: "Child", parent_id: "1" } },
+      ]);
+      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
+      expect(byValue["2"]).toBe("Top / Child");
+    });
+
+    it("disambiguates duplicate folder names under different parents", () => {
+      const options = buildFolderPickerOptions([
+        { id: "1", attributes: { name: "Networking" } },
+        { id: "2", attributes: { name: "Servers" } },
+        { id: "3", attributes: { name: "Firewalls", "parent-id": "1" } },
+        { id: "4", attributes: { name: "Firewalls", "parent-id": "2" } },
+      ]);
+      const labels = options.map((o) => o.label);
+      expect(labels).toContain("Networking / Firewalls");
+      expect(labels).toContain("Servers / Firewalls");
+    });
+
+    it("sorts folder entries alphabetically by breadcrumb label (after the sentinel)", () => {
+      const options = buildFolderPickerOptions([
+        { id: "1", attributes: { name: "Zebra" } },
+        { id: "2", attributes: { name: "Alpha" } },
+        { id: "3", attributes: { name: "Mango" } },
+      ]);
+      const folderLabels = options.slice(1).map((o) => o.label);
+      expect(folderLabels).toEqual(["Alpha", "Mango", "Zebra"]);
+    });
+
+    it("is cycle-safe — does not loop forever when parent-id points back to a descendant", () => {
+      // A → B → A (cycle). Should terminate; the resulting label is a prefix
+      // of the chain up to the repeat.
+      const options = buildFolderPickerOptions([
+        { id: "A", attributes: { name: "A", "parent-id": "B" } },
+        { id: "B", attributes: { name: "B", "parent-id": "A" } },
+      ]);
+      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
+      // Walking from A: visit A (push "A"), parent B not seen → visit B (push "B"), parent A seen → stop.
+      expect(byValue["A"]).toBe("B / A");
+      expect(byValue["B"]).toBe("A / B");
+    });
+
+    it("treats folders with unknown parent ids as orphans (labelled by own name)", () => {
+      const options = buildFolderPickerOptions([
+        { id: "1", attributes: { name: "Stray", "parent-id": "999" } },
+      ]);
+      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
+      expect(byValue["1"]).toBe("Stray");
+    });
+
+    it("falls back to a synthetic label when a folder has no name attribute", () => {
+      const options = buildFolderPickerOptions([
+        { id: "77", attributes: {} },
+      ]);
+      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
+      expect(byValue["77"]).toBe("folder 77");
+    });
+
+    it("coerces numeric parent ids to strings when looking up the parent", () => {
+      // Some IT Glue responses use numeric ids; the helper should still
+      // resolve the chain.
+      const options = buildFolderPickerOptions([
+        { id: "1", attributes: { name: "Top" } },
+        { id: "2", attributes: { name: "Child", "parent-id": 1 as unknown as string } },
+      ]);
+      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
+      expect(byValue["2"]).toBe("Top / Child");
     });
   });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -20,9 +20,9 @@ vi.stubGlobal("fetch", mockFetch);
 // its main() bootstrap on NODE_ENV=test so this import does not start an MCP
 // server during tests.
 import {
-  buildFolderPickerOptions,
   createDocumentWithContent,
   ITGlueClient,
+  parseFolderReference,
 } from "../index.js";
 
 // Store original env vars
@@ -841,97 +841,54 @@ describe("Tool Handler Integration", () => {
     });
   });
 
-  describe("buildFolderPickerOptions", () => {
-    it("always prepends a __root__ sentinel even when the folder list is empty", () => {
-      const options = buildFolderPickerOptions([]);
-      expect(options).toEqual([
-        { value: "__root__", label: "(Root — no folder)" },
-      ]);
+  describe("parseFolderReference", () => {
+    it("returns root for null, undefined, empty, and whitespace input", () => {
+      expect(parseFolderReference(null)).toEqual({ kind: "root" });
+      expect(parseFolderReference(undefined)).toEqual({ kind: "root" });
+      expect(parseFolderReference("")).toEqual({ kind: "root" });
+      expect(parseFolderReference("   \n  ")).toEqual({ kind: "root" });
     });
 
-    it("builds breadcrumb labels for nested folders using parent-id (kebab-case)", () => {
-      const options = buildFolderPickerOptions([
-        { id: "1", attributes: { name: "Networking" } },
-        { id: "2", attributes: { name: "Firewalls", "parent-id": "1" } },
-        { id: "3", attributes: { name: "Edge", "parent-id": "2" } },
-      ]);
-      // First entry is the sentinel; the rest are sorted by label.
-      expect(options[0]).toEqual({ value: "__root__", label: "(Root — no folder)" });
-      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
-      expect(byValue["1"]).toBe("Networking");
-      expect(byValue["2"]).toBe("Networking / Firewalls");
-      expect(byValue["3"]).toBe("Networking / Firewalls / Edge");
+    it("returns a folder reference for a bare numeric id (trimmed)", () => {
+      expect(parseFolderReference("6926612")).toEqual({ kind: "folder", folderId: 6926612 });
+      expect(parseFolderReference("  6926612  ")).toEqual({ kind: "folder", folderId: 6926612 });
     });
 
-    it("also accepts snake_case parent_id (for proxied/cached responses)", () => {
-      const options = buildFolderPickerOptions([
-        { id: "1", attributes: { name: "Top" } },
-        { id: "2", attributes: { name: "Child", parent_id: "1" } },
-      ]);
-      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
-      expect(byValue["2"]).toBe("Top / Child");
+    it("extracts the folder id from an IT Glue folder URL", () => {
+      const url = "https://wyretechnology.itglue.com/8250506/documents/folder/6926612/";
+      expect(parseFolderReference(url)).toEqual({ kind: "folder", folderId: 6926612 });
     });
 
-    it("disambiguates duplicate folder names under different parents", () => {
-      const options = buildFolderPickerOptions([
-        { id: "1", attributes: { name: "Networking" } },
-        { id: "2", attributes: { name: "Servers" } },
-        { id: "3", attributes: { name: "Firewalls", "parent-id": "1" } },
-        { id: "4", attributes: { name: "Firewalls", "parent-id": "2" } },
-      ]);
-      const labels = options.map((o) => o.label);
-      expect(labels).toContain("Networking / Firewalls");
-      expect(labels).toContain("Servers / Firewalls");
+    it("handles a folder URL with no trailing slash", () => {
+      const url = "https://wyretechnology.itglue.com/8250506/documents/folder/6926612";
+      expect(parseFolderReference(url)).toEqual({ kind: "folder", folderId: 6926612 });
     });
 
-    it("sorts folder entries alphabetically by breadcrumb label (after the sentinel)", () => {
-      const options = buildFolderPickerOptions([
-        { id: "1", attributes: { name: "Zebra" } },
-        { id: "2", attributes: { name: "Alpha" } },
-        { id: "3", attributes: { name: "Mango" } },
-      ]);
-      const folderLabels = options.slice(1).map((o) => o.label);
-      expect(folderLabels).toEqual(["Alpha", "Mango", "Zebra"]);
+    it("extracts the doc id from a `/docs/<id>` URL (resource-url shape)", () => {
+      const url = "https://wyretechnology.itglue.com/8250506/docs/22884804";
+      expect(parseFolderReference(url)).toEqual({ kind: "doc", docId: 22884804 });
     });
 
-    it("is cycle-safe — does not loop forever when parent-id points back to a descendant", () => {
-      // A → B → A (cycle). Should terminate; the resulting label is a prefix
-      // of the chain up to the repeat.
-      const options = buildFolderPickerOptions([
-        { id: "A", attributes: { name: "A", "parent-id": "B" } },
-        { id: "B", attributes: { name: "B", "parent-id": "A" } },
-      ]);
-      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
-      // Walking from A: visit A (push "A"), parent B not seen → visit B (push "B"), parent A seen → stop.
-      expect(byValue["A"]).toBe("B / A");
-      expect(byValue["B"]).toBe("A / B");
+    it("extracts the doc id from a `DOC-<org>-<id>` URL (UI shape)", () => {
+      const url = "https://wyretechnology.itglue.com/DOC-8250506-22884804";
+      expect(parseFolderReference(url)).toEqual({ kind: "doc", docId: 22884804 });
     });
 
-    it("treats folders with unknown parent ids as orphans (labelled by own name)", () => {
-      const options = buildFolderPickerOptions([
-        { id: "1", attributes: { name: "Stray", "parent-id": "999" } },
-      ]);
-      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
-      expect(byValue["1"]).toBe("Stray");
+    it("prefers the more specific folder pattern when both could match", () => {
+      // A folder URL is unambiguous — the doc pattern should not steal from it.
+      const url = "https://x/8250506/documents/folder/6926612/";
+      expect(parseFolderReference(url)).toEqual({ kind: "folder", folderId: 6926612 });
     });
 
-    it("falls back to a synthetic label when a folder has no name attribute", () => {
-      const options = buildFolderPickerOptions([
-        { id: "77", attributes: {} },
-      ]);
-      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
-      expect(byValue["77"]).toBe("folder 77");
-    });
-
-    it("coerces numeric parent ids to strings when looking up the parent", () => {
-      // Some IT Glue responses use numeric ids; the helper should still
-      // resolve the chain.
-      const options = buildFolderPickerOptions([
-        { id: "1", attributes: { name: "Top" } },
-        { id: "2", attributes: { name: "Child", "parent-id": 1 as unknown as string } },
-      ]);
-      const byValue = Object.fromEntries(options.map((o) => [o.value, o.label]));
-      expect(byValue["2"]).toBe("Top / Child");
+    it("flags unparseable input as invalid (preserves the original for the error message)", () => {
+      expect(parseFolderReference("not a url or id")).toEqual({
+        kind: "invalid",
+        input: "not a url or id",
+      });
+      expect(parseFolderReference("https://example.com/somewhere/else")).toEqual({
+        kind: "invalid",
+        input: "https://example.com/somewhere/else",
+      });
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,6 +291,11 @@ export async function createDocumentWithContent(
 ): Promise<Record<string, unknown>> {
   const attributes: Record<string, unknown> = { name: args.name };
   if (args.document_folder_id !== undefined && args.document_folder_id !== null) {
+    // Verified live 2026-05-12: IT Glue accepts both snake_case
+    // `document_folder_id` and kebab-case `document-folder-id` on write
+    // (both reach the same validation path; 99999999 → 422 "must exist in
+    // the same organization"). We use snake_case to match the precedent set
+    // by `resource_type` on document-sections.
     attributes.document_folder_id = args.document_folder_id;
   }
 
@@ -322,8 +327,8 @@ export async function createDocumentWithContent(
 
 /**
  * IT Glue document folder resource shape (subset we use). Folders can be
- * nested via `parent-id`; the API serialises in kebab-case but tolerant code
- * also accepts snake_case from cached/proxied responses.
+ * nested via `parent-id` (the kebab-case key IT Glue emits); the helper also
+ * accepts `parent_id` defensively.
  */
 export interface DocumentFolderResource {
   id: string;
@@ -331,16 +336,16 @@ export interface DocumentFolderResource {
 }
 
 /**
- * Build the elicitation option list shown to users when no folder is supplied
- * to `create_document`. The first option is always a `__root__` sentinel so
- * users can explicitly choose "no folder" (distinct from cancelling). Other
- * entries are labelled with breadcrumb paths (e.g. `Networking / Firewalls`)
- * so duplicate folder names under different parents stay distinguishable, and
- * the list is sorted alphabetically by label for predictable ordering.
+ * Turn a flat list of folder resources into picker options.
  *
- * Cycle-safe: a folder whose parent chain loops back on itself stops walking
- * at the repeat. Orphan folders (parent id pointing nowhere) are labelled by
- * their own name only.
+ * The `__root__` sentinel is pinned first so picking "no folder" stays
+ * distinguishable from declining the prompt. Remaining entries are labelled
+ * with their full breadcrumb path so duplicate folder names under different
+ * parents stay distinguishable, then locale-collated by label.
+ *
+ * Cycle-safe: a folder whose parent chain loops back stops walking at the
+ * repeat. Orphan folders (parent id pointing nowhere) are labelled by their
+ * own name only.
  */
 export function buildFolderPickerOptions(
   folders: DocumentFolderResource[]
@@ -656,7 +661,7 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
       },
       {
         name: "list_document_folders",
-        description: "List document folders for an organization in IT Glue. Optionally filter by folder name (partial match). Use this to discover folder IDs for create_document.",
+        description: "List document folders for an organization in IT Glue. NOTE: IT Glue requires JWT auth for this endpoint and returns 401 for API-key callers (most MCP integrations). When that happens, find the folder ID in the IT Glue web UI URL (the `folder_id` query param when viewing the folder) and pass it to create_document directly.",
         inputSchema: {
           type: "object",
           properties: {
@@ -682,7 +687,7 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
       },
       {
         name: "create_document",
-        description: "Create a new document in IT Glue for an organization. If no document_folder_id is supplied, the user will be prompted to pick a folder (or 'root') interactively when the client supports elicitation. Pass skip_folder_prompt=true to suppress the prompt and create at the root.",
+        description: "Create a new document in IT Glue for an organization. If no document_folder_id is supplied AND the IT Glue token has JWT scope (rare for API-key callers — see list_document_folders), the user will be prompted to pick a folder interactively. Otherwise the document is created at the organization root. Pass skip_folder_prompt=true to always create at the root without prompting.",
         inputSchema: {
           type: "object",
           properties: {
@@ -1269,22 +1274,43 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const skipPrompt = args.skip_folder_prompt === true;
 
         if (folderId === undefined && !skipPrompt) {
-          const foldersResp = await client.request(
-            `/organizations/${args.organization_id}/relationships/document_folders`,
-            { page: { size: 100, number: 1 } }
-          ) as { data?: DocumentFolderResource[] };
+          // IT Glue's /document_folders endpoint requires JWT auth (verified
+          // 2026-05-12: returns 401 "Only supported for JWT requests" for
+          // API-key callers). MCP gateway integrations use API keys, so this
+          // fetch will normally fail with 401 — degrade silently to "create
+          // at root" in that case and let the user supply document_folder_id
+          // directly if they need a folder. Other failures still propagate.
+          let folders: DocumentFolderResource[] = [];
+          try {
+            const foldersResp = await client.request(
+              `/organizations/${args.organization_id}/relationships/document_folders`,
+              { page: { size: 1000, number: 1 } }
+            ) as { data?: DocumentFolderResource[] };
+            folders = foldersResp?.data ?? [];
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (!msg.includes("401")) throw err;
+          }
 
-          const folders = foldersResp?.data ?? [];
           if (folders.length > 0) {
-            const options = buildFolderPickerOptions(folders);
-            const choice = await elicitSelection(
+            const result = await elicitSelection(
               `Which folder should "${args.name}" go in?`,
               "folder",
-              options
+              buildFolderPickerOptions(folders)
             );
-            if (choice && choice !== "__root__") {
-              folderId = choice;
+            if (result.status === "declined") {
+              return {
+                content: [{
+                  type: "text",
+                  text: "Document creation cancelled. Re-run with skip_folder_prompt=true, or supply document_folder_id explicitly.",
+                }],
+                isError: true,
+              };
             }
+            if (result.status === "accepted" && result.value !== "__root__") {
+              folderId = result.value;
+            }
+            // status === "unavailable" or value === "__root__": fall through with folderId undefined.
           }
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { setServerRef } from "./utils/server-ref.js";
-import { elicitText } from "./utils/elicitation.js";
+import { elicitText, elicitSelection } from "./utils/elicitation.js";
 import { registerPromptHandlers } from "./prompts.js";
 
 // IT Glue region configuration
@@ -286,14 +286,20 @@ export async function createDocumentWithContent(
     organization_id: number | string;
     name: string;
     content?: string;
+    document_folder_id?: number | string;
   }
 ): Promise<Record<string, unknown>> {
+  const attributes: Record<string, unknown> = { name: args.name };
+  if (args.document_folder_id !== undefined && args.document_folder_id !== null) {
+    attributes.document_folder_id = args.document_folder_id;
+  }
+
   const newDoc = await client.post<Record<string, unknown>>(
     `/organizations/${args.organization_id}/relationships/documents`,
     {
       data: {
         type: "documents",
-        attributes: { name: args.name },
+        attributes,
       },
     }
   );
@@ -312,6 +318,57 @@ export async function createDocumentWithContent(
   }
 
   return newDoc;
+}
+
+/**
+ * IT Glue document folder resource shape (subset we use). Folders can be
+ * nested via `parent-id`; the API serialises in kebab-case but tolerant code
+ * also accepts snake_case from cached/proxied responses.
+ */
+export interface DocumentFolderResource {
+  id: string;
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * Build the elicitation option list shown to users when no folder is supplied
+ * to `create_document`. The first option is always a `__root__` sentinel so
+ * users can explicitly choose "no folder" (distinct from cancelling). Other
+ * entries are labelled with breadcrumb paths (e.g. `Networking / Firewalls`)
+ * so duplicate folder names under different parents stay distinguishable, and
+ * the list is sorted alphabetically by label for predictable ordering.
+ *
+ * Cycle-safe: a folder whose parent chain loops back on itself stops walking
+ * at the repeat. Orphan folders (parent id pointing nowhere) are labelled by
+ * their own name only.
+ */
+export function buildFolderPickerOptions(
+  folders: DocumentFolderResource[]
+): Array<{ value: string; label: string }> {
+  const byId = new Map<string, DocumentFolderResource>(
+    folders.map((f) => [f.id, f])
+  );
+
+  const labelFor = (f: DocumentFolderResource): string => {
+    const parts: string[] = [];
+    let cur: DocumentFolderResource | undefined = f;
+    const seen = new Set<string>();
+    while (cur && !seen.has(cur.id)) {
+      seen.add(cur.id);
+      const attrs: Record<string, unknown> = cur.attributes ?? {};
+      parts.unshift(String(attrs.name ?? `folder ${cur.id}`));
+      const parentId = attrs["parent-id"] ?? attrs.parent_id;
+      cur = parentId != null ? byId.get(String(parentId)) : undefined;
+    }
+    return parts.join(" / ");
+  };
+
+  return [
+    { value: "__root__", label: "(Root — no folder)" },
+    ...folders
+      .map((f) => ({ value: String(f.id), label: labelFor(f) }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+  ];
 }
 
 // Credential extraction from gateway headers
@@ -598,8 +655,34 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
         },
       },
       {
+        name: "list_document_folders",
+        description: "List document folders for an organization in IT Glue. Optionally filter by folder name (partial match). Use this to discover folder IDs for create_document.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            organization_id: {
+              type: "number",
+              description: "Organization ID to list folders for",
+            },
+            name: {
+              type: "string",
+              description: "Filter folders by name (partial match)",
+            },
+            page_size: {
+              type: "number",
+              description: "Number of results per page (max 1000, default 50)",
+            },
+            page_number: {
+              type: "number",
+              description: "Page number to retrieve (default 1)",
+            },
+          },
+          required: ["organization_id"],
+        },
+      },
+      {
         name: "create_document",
-        description: "Create a new document in IT Glue for an organization",
+        description: "Create a new document in IT Glue for an organization. If no document_folder_id is supplied, the user will be prompted to pick a folder (or 'root') interactively when the client supports elicitation. Pass skip_folder_prompt=true to suppress the prompt and create at the root.",
         inputSchema: {
           type: "object",
           properties: {
@@ -614,6 +697,14 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
             content: {
               type: "string",
               description: "Document content (HTML supported)",
+            },
+            document_folder_id: {
+              type: "number",
+              description: "Optional folder ID to place the document in. Use list_document_folders to discover IDs.",
+            },
+            skip_folder_prompt: {
+              type: "boolean",
+              description: "If true, skip the interactive folder picker and create the document at the organization root.",
             },
           },
           required: ["organization_id", "name"],
@@ -1142,6 +1233,30 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case "list_document_folders": {
+        if (!args?.organization_id) {
+          return {
+            content: [{ type: "text", text: "Error: organization_id is required" }],
+            isError: true,
+          };
+        }
+        const params: Record<string, unknown> = {};
+        const filter: Record<string, unknown> = {};
+        if (args?.name) filter.name = args.name;
+        if (Object.keys(filter).length > 0) params.filter = filter;
+        params.page = {
+          size: (args?.page_size as number) || 50,
+          number: (args?.page_number as number) || 1,
+        };
+        const result = await client.request(
+          `/organizations/${args.organization_id}/relationships/document_folders`,
+          params
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
       case "create_document": {
         if (!args?.organization_id || !args?.name) {
           return {
@@ -1149,10 +1264,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             isError: true,
           };
         }
+
+        let folderId = args.document_folder_id as number | string | undefined;
+        const skipPrompt = args.skip_folder_prompt === true;
+
+        if (folderId === undefined && !skipPrompt) {
+          const foldersResp = await client.request(
+            `/organizations/${args.organization_id}/relationships/document_folders`,
+            { page: { size: 100, number: 1 } }
+          ) as { data?: DocumentFolderResource[] };
+
+          const folders = foldersResp?.data ?? [];
+          if (folders.length > 0) {
+            const options = buildFolderPickerOptions(folders);
+            const choice = await elicitSelection(
+              `Which folder should "${args.name}" go in?`,
+              "folder",
+              options
+            );
+            if (choice && choice !== "__root__") {
+              folderId = choice;
+            }
+          }
+        }
+
         const newDoc = await createDocumentWithContent(client, {
           organization_id: args.organization_id as number | string,
           name: args.name as string,
           content: args.content as string | undefined,
+          document_folder_id: folderId,
         });
         return {
           content: [{ type: "text", text: JSON.stringify(newDoc, null, 2) }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -650,7 +650,7 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
       },
       {
         name: "create_document",
-        description: "Create a new document in IT Glue for an organization. If neither document_folder_id nor skip_folder_prompt is supplied and the client supports elicitation, the user is asked to paste a folder URL, a sibling-document URL, or a numeric folder ID (since IT Glue's API does not expose folder names to API-key callers). Pass skip_folder_prompt=true to always create at the organization root without prompting.",
+        description: "Create a new document in IT Glue for an organization. If neither document_folder_id nor skip_folder_prompt is supplied, the user is asked to paste a folder URL, a sibling-document URL, or a numeric folder ID (since IT Glue's API does not expose folder names to API-key callers). Pass skip_folder_prompt=true to always create at the organization root without prompting.",
         inputSchema: {
           type: "object",
           properties: {
@@ -1214,7 +1214,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         if (folderId === undefined && !skipPrompt) {
           const elicited = await elicitText(
-            `Which folder should "${args.name}" go in? Paste a folder URL (https://…/documents/folder/12345/), a sibling-document URL (https://…/docs/67890), or a numeric folder ID. Leave blank to create at the organization root.`,
+            `Where should "${args.name}" go? Paste one of:\n  • a folder URL (e.g. https://…/documents/folder/12345/)\n  • a sibling document's URL (e.g. https://…/docs/67890)\n  • a folder ID number\nLeave blank to create at the organization root.`,
             "folder",
             "IT Glue folder URL, sibling-document URL, or numeric folder ID"
           );
@@ -1228,6 +1228,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               isError: true,
             };
           }
+          let siblingAtRoot = false;
           if (ref.kind === "folder") {
             folderId = ref.folderId;
           } else if (ref.kind === "doc") {
@@ -1237,10 +1238,31 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const siblingFolder = sibling.documentFolderId ?? sibling["document-folder-id"];
             if (siblingFolder != null) {
               folderId = siblingFolder as number | string;
+            } else {
+              // The user pasted a sibling URL expecting placement; surface that
+              // the sibling itself is at root so "created at root" isn't a
+              // surprise.
+              siblingAtRoot = true;
             }
-            // If the sibling lives at the root, fall through with folderId undefined.
           }
           // ref.kind === "root" (elicit blank/null/unsupported): fall through with folderId undefined.
+
+          if (siblingAtRoot) {
+            const newDoc = await createDocumentWithContent(client, {
+              organization_id: args.organization_id as number | string,
+              name: args.name as string,
+              content: args.content as string | undefined,
+              document_folder_id: folderId,
+            });
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Note: the sibling document you referenced lives at the organization root, so the new document was also created at the root.\n\n${JSON.stringify(newDoc, null, 2)}`,
+                },
+              ],
+            };
+          }
         }
 
         const newDoc = await createDocumentWithContent(client, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { setServerRef } from "./utils/server-ref.js";
-import { elicitText, elicitSelection } from "./utils/elicitation.js";
+import { elicitText } from "./utils/elicitation.js";
 import { registerPromptHandlers } from "./prompts.js";
 
 // IT Glue region configuration
@@ -326,54 +326,43 @@ export async function createDocumentWithContent(
 }
 
 /**
- * IT Glue document folder resource shape (subset we use). Folders can be
- * nested via `parent-id` (the kebab-case key IT Glue emits); the helper also
- * accepts `parent_id` defensively.
- */
-export interface DocumentFolderResource {
-  id: string;
-  attributes?: Record<string, unknown>;
-}
-
-/**
- * Turn a flat list of folder resources into picker options.
+ * Parse a folder reference supplied by the user. Folder *names* are not
+ * reachable with API-key auth (IT Glue gates `/document_folders` behind a
+ * user-session JWT — see the README for the JWT escape hatch). So the
+ * elicitation path accepts inputs the user can copy out of their browser
+ * tab while looking at the folder they want:
  *
- * The `__root__` sentinel is pinned first so picking "no folder" stays
- * distinguishable from declining the prompt. Remaining entries are labelled
- * with their full breadcrumb path so duplicate folder names under different
- * parents stay distinguishable, then locale-collated by label.
- *
- * Cycle-safe: a folder whose parent chain loops back stops walking at the
- * repeat. Orphan folders (parent id pointing nowhere) are labelled by their
- * own name only.
+ *   - empty / whitespace → root
+ *   - bare numeric id    → folder
+ *   - URL containing `/documents/folder/<id>/` → folder
+ *   - URL containing `/docs/<id>` or `/DOC-<org>-<id>` → doc (caller GETs
+ *     the doc and reads its `document-folder-id` to resolve the folder)
+ *   - anything else      → invalid
  */
-export function buildFolderPickerOptions(
-  folders: DocumentFolderResource[]
-): Array<{ value: string; label: string }> {
-  const byId = new Map<string, DocumentFolderResource>(
-    folders.map((f) => [f.id, f])
-  );
+export type FolderReference =
+  | { kind: "root" }
+  | { kind: "folder"; folderId: number }
+  | { kind: "doc"; docId: number }
+  | { kind: "invalid"; input: string };
 
-  const labelFor = (f: DocumentFolderResource): string => {
-    const parts: string[] = [];
-    let cur: DocumentFolderResource | undefined = f;
-    const seen = new Set<string>();
-    while (cur && !seen.has(cur.id)) {
-      seen.add(cur.id);
-      const attrs: Record<string, unknown> = cur.attributes ?? {};
-      parts.unshift(String(attrs.name ?? `folder ${cur.id}`));
-      const parentId = attrs["parent-id"] ?? attrs.parent_id;
-      cur = parentId != null ? byId.get(String(parentId)) : undefined;
-    }
-    return parts.join(" / ");
-  };
+export function parseFolderReference(input: string | null | undefined): FolderReference {
+  if (input == null) return { kind: "root" };
+  const trimmed = input.trim();
+  if (trimmed === "") return { kind: "root" };
 
-  return [
-    { value: "__root__", label: "(Root — no folder)" },
-    ...folders
-      .map((f) => ({ value: String(f.id), label: labelFor(f) }))
-      .sort((a, b) => a.label.localeCompare(b.label)),
-  ];
+  if (/^\d+$/.test(trimmed)) {
+    return { kind: "folder", folderId: Number(trimmed) };
+  }
+
+  const folderMatch = trimmed.match(/\/documents\/folder\/(\d+)/);
+  if (folderMatch) return { kind: "folder", folderId: Number(folderMatch[1]) };
+
+  const docMatch =
+    trimmed.match(/\/docs\/(\d+)/) ??
+    trimmed.match(/\/DOC-\d+-(\d+)/i);
+  if (docMatch) return { kind: "doc", docId: Number(docMatch[1]) };
+
+  return { kind: "invalid", input: trimmed };
 }
 
 // Credential extraction from gateway headers
@@ -660,34 +649,8 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
         },
       },
       {
-        name: "list_document_folders",
-        description: "List document folders for an organization in IT Glue. NOTE: IT Glue requires JWT auth for this endpoint and returns 401 for API-key callers (most MCP integrations). When that happens, find the folder ID in the IT Glue web UI URL (the `folder_id` query param when viewing the folder) and pass it to create_document directly.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            organization_id: {
-              type: "number",
-              description: "Organization ID to list folders for",
-            },
-            name: {
-              type: "string",
-              description: "Filter folders by name (partial match)",
-            },
-            page_size: {
-              type: "number",
-              description: "Number of results per page (max 1000, default 50)",
-            },
-            page_number: {
-              type: "number",
-              description: "Page number to retrieve (default 1)",
-            },
-          },
-          required: ["organization_id"],
-        },
-      },
-      {
         name: "create_document",
-        description: "Create a new document in IT Glue for an organization. If no document_folder_id is supplied AND the IT Glue token has JWT scope (rare for API-key callers — see list_document_folders), the user will be prompted to pick a folder interactively. Otherwise the document is created at the organization root. Pass skip_folder_prompt=true to always create at the root without prompting.",
+        description: "Create a new document in IT Glue for an organization. If neither document_folder_id nor skip_folder_prompt is supplied and the client supports elicitation, the user is asked to paste a folder URL, a sibling-document URL, or a numeric folder ID (since IT Glue's API does not expose folder names to API-key callers). Pass skip_folder_prompt=true to always create at the organization root without prompting.",
         inputSchema: {
           type: "object",
           properties: {
@@ -705,7 +668,7 @@ function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
             },
             document_folder_id: {
               type: "number",
-              description: "Optional folder ID to place the document in. Use list_document_folders to discover IDs.",
+              description: "Optional folder ID to place the document in. Find folder IDs in the IT Glue web URL (e.g. `/documents/folder/12345/`) or by inspecting `document-folder-id` on an existing document in that folder.",
             },
             skip_folder_prompt: {
               type: "boolean",
@@ -1238,30 +1201,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "list_document_folders": {
-        if (!args?.organization_id) {
-          return {
-            content: [{ type: "text", text: "Error: organization_id is required" }],
-            isError: true,
-          };
-        }
-        const params: Record<string, unknown> = {};
-        const filter: Record<string, unknown> = {};
-        if (args?.name) filter.name = args.name;
-        if (Object.keys(filter).length > 0) params.filter = filter;
-        params.page = {
-          size: (args?.page_size as number) || 50,
-          number: (args?.page_number as number) || 1,
-        };
-        const result = await client.request(
-          `/organizations/${args.organization_id}/relationships/document_folders`,
-          params
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
       case "create_document": {
         if (!args?.organization_id || !args?.name) {
           return {
@@ -1274,44 +1213,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const skipPrompt = args.skip_folder_prompt === true;
 
         if (folderId === undefined && !skipPrompt) {
-          // IT Glue's /document_folders endpoint requires JWT auth (verified
-          // 2026-05-12: returns 401 "Only supported for JWT requests" for
-          // API-key callers). MCP gateway integrations use API keys, so this
-          // fetch will normally fail with 401 — degrade silently to "create
-          // at root" in that case and let the user supply document_folder_id
-          // directly if they need a folder. Other failures still propagate.
-          let folders: DocumentFolderResource[] = [];
-          try {
-            const foldersResp = await client.request(
-              `/organizations/${args.organization_id}/relationships/document_folders`,
-              { page: { size: 1000, number: 1 } }
-            ) as { data?: DocumentFolderResource[] };
-            folders = foldersResp?.data ?? [];
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            if (!msg.includes("401")) throw err;
+          const elicited = await elicitText(
+            `Which folder should "${args.name}" go in? Paste a folder URL (https://…/documents/folder/12345/), a sibling-document URL (https://…/docs/67890), or a numeric folder ID. Leave blank to create at the organization root.`,
+            "folder",
+            "IT Glue folder URL, sibling-document URL, or numeric folder ID"
+          );
+          const ref = parseFolderReference(elicited);
+          if (ref.kind === "invalid") {
+            return {
+              content: [{
+                type: "text",
+                text: `Could not parse folder reference "${ref.input}". Expected a folder URL, a document URL, a numeric folder ID, or an empty value for root.`,
+              }],
+              isError: true,
+            };
           }
-
-          if (folders.length > 0) {
-            const result = await elicitSelection(
-              `Which folder should "${args.name}" go in?`,
-              "folder",
-              buildFolderPickerOptions(folders)
+          if (ref.kind === "folder") {
+            folderId = ref.folderId;
+          } else if (ref.kind === "doc") {
+            const sibling = await client.get<Record<string, unknown>>(
+              `/organizations/${args.organization_id}/relationships/documents/${ref.docId}`
             );
-            if (result.status === "declined") {
-              return {
-                content: [{
-                  type: "text",
-                  text: "Document creation cancelled. Re-run with skip_folder_prompt=true, or supply document_folder_id explicitly.",
-                }],
-                isError: true,
-              };
+            const siblingFolder = sibling.documentFolderId ?? sibling["document-folder-id"];
+            if (siblingFolder != null) {
+              folderId = siblingFolder as number | string;
             }
-            if (result.status === "accepted" && result.value !== "__root__") {
-              folderId = result.value;
-            }
-            // status === "unavailable" or value === "__root__": fall through with folderId undefined.
+            // If the sibling lives at the root, fall through with folderId undefined.
           }
+          // ref.kind === "root" (elicit blank/null/unsupported): fall through with folderId undefined.
         }
 
         const newDoc = await createDocumentWithContent(client, {

--- a/src/utils/elicitation.ts
+++ b/src/utils/elicitation.ts
@@ -10,15 +10,26 @@ export interface ElicitOption {
 }
 
 /**
+ * Result of an `elicitSelection` call. Three states are surfaced so callers
+ * can distinguish "user said no" (typically an error) from "client cannot
+ * ask" (typically a silent fallback). Collapsing both into `null` loses
+ * meaning the caller often needs.
+ */
+export type ElicitSelectionResult =
+  | { status: "accepted"; value: string }
+  | { status: "declined" }
+  | { status: "unavailable" };
+
+/**
  * Ask the user to select from a list of options.
  */
 export async function elicitSelection(
   message: string,
   fieldName: string,
   options: ElicitOption[]
-): Promise<string | null> {
+): Promise<ElicitSelectionResult> {
   const server = getServerRef();
-  if (!server) return null;
+  if (!server) return { status: "unavailable" };
 
   try {
     const result = await server.elicitInput({
@@ -39,11 +50,11 @@ export async function elicitSelection(
     });
 
     if (result.action === "accept" && result.content) {
-      return result.content[fieldName] as string;
+      return { status: "accepted", value: result.content[fieldName] as string };
     }
-    return null;
+    return { status: "declined" };
   } catch {
-    return null;
+    return { status: "unavailable" };
   }
 }
 

--- a/src/utils/elicitation.ts
+++ b/src/utils/elicitation.ts
@@ -10,26 +10,15 @@ export interface ElicitOption {
 }
 
 /**
- * Result of an `elicitSelection` call. Three states are surfaced so callers
- * can distinguish "user said no" (typically an error) from "client cannot
- * ask" (typically a silent fallback). Collapsing both into `null` loses
- * meaning the caller often needs.
- */
-export type ElicitSelectionResult =
-  | { status: "accepted"; value: string }
-  | { status: "declined" }
-  | { status: "unavailable" };
-
-/**
  * Ask the user to select from a list of options.
  */
 export async function elicitSelection(
   message: string,
   fieldName: string,
   options: ElicitOption[]
-): Promise<ElicitSelectionResult> {
+): Promise<string | null> {
   const server = getServerRef();
-  if (!server) return { status: "unavailable" };
+  if (!server) return null;
 
   try {
     const result = await server.elicitInput({
@@ -50,11 +39,11 @@ export async function elicitSelection(
     });
 
     if (result.action === "accept" && result.content) {
-      return { status: "accepted", value: result.content[fieldName] as string };
+      return result.content[fieldName] as string;
     }
-    return { status: "declined" };
+    return null;
   } catch {
-    return { status: "unavailable" };
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
Adds folder placement to `create_document` using the only path that works with API-key auth alone — no JWT required.

## What changed
- `create_document` accepts optional `document_folder_id` and `skip_folder_prompt`.
- When neither is supplied and the client supports elicitation, the user is prompted for a **folder URL**, **sibling-document URL**, or **bare numeric folder ID**. All three are things they can copy out of their browser tab while looking at the folder they want. (Folder names are not reachable with API-key auth — this is verified, documented, and corroborated by the wider IT Glue tooling ecosystem.)
- New exported pure helper `parseFolderReference(input)` returns a discriminated `FolderReference` union (`root | folder | doc | invalid`) so the input parsing is unit-testable in isolation.
- Doc-URL inputs cost one extra GET on the sibling doc to read its `document-folder-id`; folder URLs and bare IDs are zero additional API calls.

## Why this shape
Empirically and via cross-referenced research, IT Glue's `/document_folders` endpoint returns 401 \"Only supported for JWT requests\" for API-key callers. JWTs come only from an interactive OIDC flow against Kaseya One (no client-credentials grant — confirmed at the OIDC discovery doc). Across every PowerShell wrapper (Celerium, the canonical itglue/powershellwrapper, CalebAlbers, wetling23, etc.) and Hudu's IT Glue migration tool, the convention is identical: either skip folder enumeration entirely, or prompt the user for a browser-extracted JWT. The latter is appropriate for a future tier but unnecessary for the core \"place a doc in a folder\" workflow.

Live-verified 2026-05-12 against api.itglue.com: `document_folder_id` POST attribute placement works with API-key auth (HTTP 201, response echoes the correct `document-folder-id`).

## Followup (separate PR)
Tier 3 will add optional JWT credential support so name-based folder discovery becomes available for users who paste a JWT (Hudu-style), with a possible cookie-jar-based silent refresh helper to make the 2h TTL invisible.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 124 passing
- [x] Helper coverage: `parseFolderReference` for null/empty/whitespace, bare numeric (with trim), folder URL (with/without trailing slash), `/docs/<id>` URL, `DOC-<org>-<id>` URL, precedence between folder & doc patterns, and invalid input preservation.
- [x] `createDocumentWithContent` includes/omits `document_folder_id` correctly (number, string, missing).
- [x] Live POST against a real IT Glue tenant confirmed folder placement works with API-key auth.