### PR TITLE
chore(release): use shared mcp-server-deploy reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -96,6 +98,7 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push
+        id: push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
@@ -170,28 +173,12 @@ jobs:
 
   deploy:
     name: Deploy to Azure Container Apps
-    runs-on: ubuntu-latest
-    needs: [docker]
+    needs: [release, docker]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment: production
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Azure login (OIDC)
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  # v2.3.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Deploy to Azure Container Apps
-        run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          IMAGE="ghcr.io/${{ github.repository }}:latest"
-          echo "Deploying $IMAGE to mcpgw-prod-itglue (revision tag sha-${SHORT_SHA}-${GITHUB_RUN_ID})"
-          az containerapp update \
-            --name mcpgw-prod-itglue \
-            --resource-group mcp-gateway-prod \
-            --image "$IMAGE" \
-            --set-env-vars "IMAGE_VERSION=sha-${SHORT_SHA}-${GITHUB_RUN_ID}"
+    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@c2d6fc89211757997102d100115d02997d4e3521
+    with:
+      vendor-slug: itglue
+      image-name: ghcr.io/wyre-technology/itglue-mcp
+      digest: ${{ needs.docker.outputs.digest }}
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Converts itglue-mcp's deploy job to the canonical reusable workflow at `wyre-technology/.github/.github/workflows/mcp-server-deploy.yml` (pinned to merge SHA `c2d6fc8`).

Fleet-wide bug: the previous inline deploy targeted the orphaned `mcpgw-prod-itglue` ACA by mutable `:latest` tag. Real production ACA is `gwp-itglue`, and we now deploy by image digest to eliminate the publish/deploy race.

Same conversion as autotask-mcp#98.

## Changes

- `docker` job: expose `digest` output via `steps.push.outputs.digest`
- `deploy` job: replaced inline shell with reusable workflow call, passing `vendor-slug`, `image-name`, `digest`, and `version`

## Test plan

- [ ] CI passes
- [ ] On merge, deploy job runs reusable workflow against `gwp-itglue` by digest
- [ ] Verify revision reflects the just-built image