### PR TITLE
fix(release): grant id-token: write on deploy job (unblocks OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,9 @@ jobs:
     name: Deploy to Azure Container Apps
     needs: [release, docker]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: read
     uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@d6ace529b210900f460cb365529f2a552daedf7a
     with:
       vendor-slug: itglue


### PR DESCRIPTION
Last sweep's release runs all failed with:

  `The nested job 'deploy' is requesting 'id-token: write', but is only allowed 'id-token: none'.`

The reusable deploy workflow declares `id-token: write` at its job level for Azure OIDC, but reusable workflows can only USE permissions the caller has GRANTED. My earlier refactor dropped the inline deploy job's permissions block; this PR restores it (job-scoped, not workflow-wide).

After merge, the next release should actually execute the deploy job and land on `gwp-<vendor>` by digest.