### PR TITLE
docs: document remote HTTP Streamable deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ The server accepts credentials via environment variables:
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `ITGLUE_API_KEY` | Your IT Glue API key (format: ITG.xxx) | Yes |
+| `ITGLUE_API_KEY` | Your IT Glue API key (format: ITG.xxx) | Yes (env mode) |
 | `ITGLUE_REGION` | API region: `us`, `eu`, or `au` (default: `us`) | No |
+| `MCP_TRANSPORT` | Transport: `stdio` (local) or `http` (remote). Defaults to `stdio` when run via `npx`/`node`, and to `http` in the Docker image. | No |
+| `MCP_HTTP_PORT` | Port for HTTP transport (default: `8080`) | No |
+| `MCP_HTTP_HOST` | Bind address for HTTP transport (default: `0.0.0.0`) | No |
+| `AUTH_MODE` | `env` (read credentials from environment) or `gateway` (read per-request credentials from HTTP headers). Default: `env`. | No |
 
-Alternative: The MCP Gateway can inject credentials via `X_API_KEY` header.
+Alternative: When `AUTH_MODE=gateway`, the MCP Gateway injects credentials per request via HTTP headers instead of environment variables. See [Remote Deployment](#remote-deployment-http-streamable).
 
 ## Available Tools
 
@@ -79,20 +83,87 @@ Add to your `.mcp.json`:
 }
 ```
 
-Or with Docker:
+Or with Docker (local stdio):
 
 ```json
 {
   "mcpServers": {
     "itglue": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "-e", "ITGLUE_API_KEY", "ghcr.io/wyre-technology/itglue-mcp:latest"],
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "MCP_TRANSPORT=stdio",
+        "-e", "ITGLUE_API_KEY",
+        "ghcr.io/wyre-technology/itglue-mcp:latest"
+      ],
       "env": {
         "ITGLUE_API_KEY": "${ITGLUE_API_KEY}"
       }
     }
   }
 }
+```
+
+> **Note:** The Docker image defaults to HTTP transport. The `-e MCP_TRANSPORT=stdio` above is required to run it as a local stdio server for Claude Desktop/Code. For server deployments, see [Remote Deployment](#remote-deployment-http-streamable) below.
+
+## Remote Deployment (HTTP Streamable)
+
+For server/cloud deployments, run the server with the HTTP Streamable transport. The Docker image already defaults to `MCP_TRANSPORT=http` on port `8080`, exposing two endpoints:
+
+- `POST /mcp` — MCP Streamable HTTP endpoint (stateless: a fresh server is created per request)
+- `GET /health` — unauthenticated health check
+
+### Env mode (single tenant)
+
+Credentials come from environment variables. Use this when one API key serves the deployment:
+
+```bash
+docker run -d \
+  --name itglue-mcp \
+  -p 8080:8080 \
+  -e ITGLUE_API_KEY="ITG.xxxxxxxx" \
+  -e ITGLUE_REGION="us" \
+  --restart unless-stopped \
+  ghcr.io/wyre-technology/itglue-mcp:latest
+
+# Verify
+curl http://localhost:8080/health
+# {"status":"ok","transport":"http","authMode":"env",...}
+```
+
+Clients connect to `http://<host>:8080/mcp` using the MCP Streamable HTTP transport.
+
+### Gateway mode (multi-tenant / hosted)
+
+When deployed behind an MCP Gateway (e.g. `mcp.wyre.ai`), set `AUTH_MODE=gateway`. Credentials are then injected per request via HTTP headers rather than environment variables:
+
+```bash
+docker run -d \
+  --name itglue-mcp \
+  -p 8080:8080 \
+  -e AUTH_MODE=gateway \
+  --restart unless-stopped \
+  ghcr.io/wyre-technology/itglue-mcp:latest
+```
+
+The gateway supplies credentials on each request via these headers:
+
+| Header | Description | Required |
+|--------|-------------|----------|
+| `X-ITGlue-API-Key` (or `X-API-Key`) | IT Glue API key | One of API-Key or JWT |
+| `X-ITGlue-JWT` | JWT for elevated-scope operations | One of API-Key or JWT |
+| `X-ITGlue-Region` | API region: `us`, `eu`, or `au` (default: `us`) | No |
+| `X-ITGlue-Base-URL` | Override the IT Glue API base URL | No |
+
+Requests missing both `X-ITGlue-API-Key` and `X-ITGlue-JWT` receive a `401`. The `/health` endpoint reports `"authMode":"gateway"` in this mode.
+
+### Running without Docker
+
+The same transport works from an installed/built copy by setting `MCP_TRANSPORT=http`:
+
+```bash
+MCP_TRANSPORT=http MCP_HTTP_PORT=8080 ITGLUE_API_KEY="ITG.xxxxxxxx" \
+  npx @wyre-technology/itglue-mcp
 ```
 
 ## Example Queries


### PR DESCRIPTION
Closes #38

The README had no guidance for running the server as a remote/HTTP deployment (the gap [#38](https://github.com/wyre-technology/itglue-mcp/issues/38) called out, comparing to autotask-mcp).

## Changes
- **New "Remote Deployment (HTTP Streamable)" section** covering:
  - **Env mode** — single-tenant `docker run` with `ITGLUE_API_KEY`, `/mcp` + `/health` endpoints, verification curl.
  - **Gateway mode** — `AUTH_MODE=gateway` with per-request header injection. Header table documents the *actual* headers the server reads (`X-ITGlue-API-Key`/`X-API-Key`, `X-ITGlue-JWT`, `X-ITGlue-Region`, `X-ITGlue-Base-URL`) — these differ from autotask's, so they were sourced from `startHttpTransport()` in `src/index.ts`, not copied.
  - Non-Docker invocation via `MCP_TRANSPORT=http`.
- **Configuration table** now lists `MCP_TRANSPORT`, `MCP_HTTP_PORT`, `MCP_HTTP_HOST`, `AUTH_MODE`.
- **Fixed the local Docker (stdio) example** — it omitted `MCP_TRANSPORT=stdio`, but the Docker image defaults to HTTP transport, so the old example would have silently started in HTTP mode.

Docs-only; no code changes.