### PR TITLE
fix: validate IT Glue region and fail clearly on unknown values

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -179,6 +179,39 @@ describe("ITGlueClient", () => {
       process.env.ITGLUE_REGION = "au";
       expect(process.env.ITGLUE_REGION).toBe("au");
     });
+
+    it("should resolve the US base URL for region 'us'", async () => {
+      mockFetch.mockImplementation(() => createMockResponse(createJsonApiResponse([])));
+      const client = new ITGlueClient({ apiKey: "test-api-key", region: "us" });
+      await client.request("/organizations");
+      expect(mockFetch.mock.calls[0][0]).toMatch(/^https:\/\/api\.itglue\.com\/organizations/);
+    });
+
+    it("should resolve the EU base URL for region 'eu'", async () => {
+      mockFetch.mockImplementation(() => createMockResponse(createJsonApiResponse([])));
+      const client = new ITGlueClient({ apiKey: "test-api-key", region: "eu" });
+      await client.request("/organizations");
+      expect(mockFetch.mock.calls[0][0]).toMatch(/^https:\/\/api\.eu\.itglue\.com\/organizations/);
+    });
+
+    it("should throw a clear error for an unknown region instead of producing an 'undefined' URL", () => {
+      // Reproduces issue #40: ITGLUE_REGION set to an account subdomain (not us/eu/au)
+      // previously yielded baseUrl=undefined and a "Failed to parse URL from undefined/..." error.
+      expect(
+        () => new ITGlueClient({ apiKey: "test-api-key", region: "our-itg-subdomain" as never })
+      ).toThrowError(/Invalid.*region/i);
+    });
+
+    it("should still honor an explicit baseUrl even when region is unknown", async () => {
+      mockFetch.mockImplementation(() => createMockResponse(createJsonApiResponse([])));
+      const client = new ITGlueClient({
+        apiKey: "test-api-key",
+        region: "our-itg-subdomain" as never,
+        baseUrl: "https://api.itglue.example",
+      });
+      await client.request("/organizations");
+      expect(mockFetch.mock.calls[0][0]).toMatch(/^https:\/\/api\.itglue\.example\/organizations/);
+    });
   });
 
   describe("API Request Building", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,26 @@ export class ITGlueClient {
     }
     this.apiKey = config.apiKey;
     this.jwt = config.jwt;
-    this.baseUrl = config.baseUrl || REGION_URLS[config.region || "us"];
+
+    if (config.baseUrl) {
+      this.baseUrl = config.baseUrl;
+    } else {
+      const region = config.region || "us";
+      // REGION_URLS is keyed by ITGlueRegion, but callers reach this via an
+      // `as ITGlueRegion` cast on ITGLUE_REGION / X-ITGlue-Region, so the value
+      // can be any string at runtime. Validate explicitly: an unknown region
+      // used to yield baseUrl=undefined and a "Failed to parse URL from
+      // undefined/..." error downstream (issue #40).
+      const regionUrl = (REGION_URLS as Record<string, string>)[region];
+      if (!regionUrl) {
+        throw new Error(
+          `Invalid IT Glue region "${region}". Valid regions are: ${Object.keys(REGION_URLS).join(", ")}. ` +
+            `ITGLUE_REGION is the IT Glue API region, not your account subdomain. ` +
+            `To target a custom API endpoint, set ITGLUE_BASE_URL instead.`
+        );
+      }
+      this.baseUrl = regionUrl;
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #40

## Symptom
A user set `ITGLUE_REGION="our-itg-subdomain"` and every tool call returned:
```
Error: Failed to parse URL from undefined/organizations?filter%5Bname%5D=Contoso&...
```

## Root cause
`getCredentialsFromEnv()` (and the gateway header path) coerce the raw value with `as ITGlueRegion`, so any string reaches `ITGlueClient`. The constructor did:
```ts
this.baseUrl = config.baseUrl || REGION_URLS[config.region || "us"];
```
For an unknown region, `REGION_URLS[region]` is `undefined` → `baseUrl` is `undefined` → requests are built against `"undefined/organizations?..."` → `fetch` throws the parse error.

## Fix
Validate the region at the `ITGlueClient` constructor — the single chokepoint shared by both the env and gateway credential paths (defense in depth). An unknown region now throws a clear, actionable error:

> Invalid IT Glue region "our-itg-subdomain". Valid regions are: us, eu, au. ITGLUE_REGION is the IT Glue API region, not your account subdomain. To target a custom API endpoint, set ITGLUE_BASE_URL instead.

This directly addresses the reporter's actual misconception (region ≠ subdomain) and surfaces via the existing tool error wrapper (`isError: true`) rather than the cryptic `undefined` URL. An explicit `ITGLUE_BASE_URL` still overrides region resolution.

### Design choice: fail loud vs. silent fallback
I chose a hard error over silently defaulting to `us`. Silently falling back would transmit an EU/AU customer's API key to the US endpoint and mask the misconfiguration; failing fast is safer and matches the constructor's existing "requires either an apiKey or a jwt" convention.

## Tests
Added real `ITGlueClient` tests (the prior "region" tests only exercised `||` logic inline): us/eu base-URL resolution, the unknown-region throw (reproduces #40 — red before the fix), and that an explicit `baseUrl` overrides an unknown region. Full suite (139), typecheck, and lint all pass.