### PR TITLE
ci: authenticate semantic-release npm publish to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+      - name: Configure npm for GitHub Packages
+        run: |
+          echo "@wyre-technology:registry=https://npm.pkg.github.com" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: npm ci
       - run: npm run build
       - name: Capture pre-release version
@@ -47,6 +51,7 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
 
       - name: Get released version


### PR DESCRIPTION
Fixes the Release job 401 when publishing to GitHub Packages.

semantic-release's npm publish was getting `401 Unauthorized - PUT https://npm.pkg.github.com/@wyre-technology%2fitglue-mcp` because the release job lacked GitHub Packages auth.

Mirrors the proven-good ninjaone-mcp setup:
- Add 'Configure npm for GitHub Packages' step writing .npmrc with the @wyre-technology registry + _authToken
- Add NPM_TOKEN=${{ secrets.GITHUB_TOKEN }} to the Semantic Release step

packages: write was already present. Minimal change to fix the 401.