### PR TITLE
docs: document ITGLUE_JWT for document-folder operations (closes #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,41 @@ The server accepts credentials via environment variables:
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `ITGLUE_API_KEY` | Your IT Glue API key (format: ITG.xxx) | Yes (env mode) |
+| `ITGLUE_JWT` | A user-session JWT for elevated-scope operations such as listing document folders. See [JWT for document-folder operations](#jwt-for-document-folder-operations). | No |
 | `ITGLUE_REGION` | API region: `us`, `eu`, or `au` (default: `us`) | No |
+| `ITGLUE_BASE_URL` | Override the IT Glue API base URL (advanced) | No |
 | `MCP_TRANSPORT` | Transport: `stdio` (local) or `http` (remote). Defaults to `stdio` when run via `npx`/`node`, and to `http` in the Docker image. | No |
 | `MCP_HTTP_PORT` | Port for HTTP transport (default: `8080`) | No |
 | `MCP_HTTP_HOST` | Bind address for HTTP transport (default: `0.0.0.0`) | No |
 | `AUTH_MODE` | `env` (read credentials from environment) or `gateway` (read per-request credentials from HTTP headers). Default: `env`. | No |
 
 Alternative: When `AUTH_MODE=gateway`, the MCP Gateway injects credentials per request via HTTP headers instead of environment variables. See [Remote Deployment](#remote-deployment-http-streamable).
+
+### JWT for document-folder operations
+
+A handful of operations need more than an API key. IT Glue gates **document folders** behind a user-session JWT — the API-key scope can read and create documents, but it cannot enumerate folder names. Tools affected:
+
+- `list_document_folders` — fails without a JWT.
+- `create_document` — works without a JWT (falls back to a URL/ID folder prompt), but only offers the friendlier name-based folder picker when a JWT is present.
+
+Provide the JWT in whichever way matches your deployment:
+
+| Mode | How to supply the JWT |
+|------|-----------------------|
+| Local / env (`AUTH_MODE=env`) | Set the `ITGLUE_JWT` environment variable. |
+| Remote gateway (`AUTH_MODE=gateway`) | Send the `X-ITGlue-JWT` request header. |
+| Interactive clients (Claude Desktop/Code) | Leave it unset — the server prompts you to paste a JWT on first use and caches it for the session. |
+
+> **Headless deployments (Docker, cloud):** there is no one to answer the interactive prompt, so you **must** set `ITGLUE_JWT` (env mode) or send `X-ITGlue-JWT` (gateway mode) for folder enumeration to work.
+
+**Retrieving a JWT from your browser:**
+
+1. Sign in to IT Glue in your browser.
+2. Open DevTools → **Network** tab.
+3. Click any request to `itg-api-*.itglue.com`.
+4. Copy the value of the `Authorization: Bearer <token>` request header — the `<token>` part is your JWT.
+
+> **Expiry:** IT Glue JWTs are short-lived (~2 hours). A JWT placed in `ITGLUE_JWT` on a long-running container will go stale and folder enumeration will start failing until it is refreshed. Interactive clients are simply re-prompted on expiry. API-key-only operations (everything except folder enumeration) are unaffected.
 
 ## Available Tools
 
@@ -76,6 +104,7 @@ Alternative: When `AUTH_MODE=gateway`, the MCP Gateway injects credentials per r
 ### Documents
 
 - **search_documents** - Search for documents with filtering by organization or name
+- **list_document_folders** - List an organization's document folders (names and IDs). Requires a JWT — see [JWT for document-folder operations](#jwt-for-document-folder-operations)
 
 ### Flexible Assets
 


### PR DESCRIPTION
## Problem (#45)

A user deploying via Docker reported *"Subfolder enumeration requires JWT credential. No environment variable available to pass."* when searching documents under an org.

Root cause is **discoverability, not a missing feature**. The JWT plumbing already exists and works:
- `ITGLUE_JWT` env var is read unconditionally (`src/index.ts:467`)
- `X-ITGlue-JWT` gateway header
- interactive paste-on-prompt with session caching

…but `ITGLUE_JWT` was **completely absent from the README**, and the error message tells users to *"See README for how to retrieve a JWT from your browser"* — instructions that didn't exist. A headless Docker/env-mode user reads the config table, sees no JWT row, and concludes there's no way to supply one.

## Fix (docs only)

- Add `ITGLUE_JWT` (and the parallel-omitted `ITGLUE_BASE_URL`) to the Configuration env-var table.
- Add a **"JWT for document-folder operations"** section: which tools need a JWT (`list_document_folders`, the name-based folder picker in `create_document`), how to supply it per mode (env / gateway header / interactive paste), browser DevTools retrieval steps, and the **~2h expiry** caveat that bites long-running containers.
- Surface `list_document_folders` in the Documents tool list.

No code change — the capability already shipped in v1.11.1; this makes it findable.

Closes #45