### PR TITLE
build(deps-dev): adopt TypeScript 6 (fleet canary 1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    ignore:
-      # TypeScript 6.0 drops Node/web globals (process, fetch, Response, URL)
-      # unless tsconfig lib/types are reworked. Revisit as a deliberate
-      # migration; stay on the latest 5.x in the meantime.
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
     groups:
       # Bundle all non-major npm updates into a single PR to cut noise.
       npm-minor-patch:

--- a/docs/superpowers/plans/2026-06-08-ts6-fleet-migration.md
+++ b/docs/superpowers/plans/2026-06-08-ts6-fleet-migration.md
@@ -1,0 +1,327 @@
+# TypeScript 6 Fleet-Migration Capability — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and validate a reusable capability to migrate the WYRE MCP fleet to TypeScript 6 — two green canaries, an idempotent codemod, a `ts6-fleet-migration` skill, a Taskmaster tracker, and TS6-ready scaffolding skills — without fanning out to all repos yet.
+
+**Architecture:** The fix is `compilerOptions.types: ["node"]` + `typescript@^6` per repo (spike-confirmed). A dependency-free Node codemod applies it dialect-agnostically. Two canaries (`itglue-mcp` = NodeNext+lib dialect with `worker.ts`; `huntress-mcp` = bundler dialect) prove it. The capability is then frozen into a skill + tracker, and the scaffolding skills are updated so new repos are born TS6-ready.
+
+**Tech Stack:** Node 20+, TypeScript 6, npm, gh CLI, Taskmaster MCP, skill-creator skill.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-ts6-fleet-migration-design.md`
+
+---
+
+## File Structure
+
+- Create: `~/.claude/skills/ts6-fleet-migration/codemod.mjs` — the idempotent codemod (durable home: the skill).
+- Create: `~/.claude/skills/ts6-fleet-migration/SKILL.md` — runbook: codemod usage, subagent dispatch pattern, verify checklist, dialect notes, in-scope/out-of-scope list.
+- Modify (canary 1, branch `chore/ts6-migration`): `itglue-mcp/tsconfig.json`, `itglue-mcp/package.json`, `itglue-mcp/.github/dependabot.yml`.
+- Modify (canary 2, its own branch/worktree): `huntress-mcp/tsconfig.json`, `huntress-mcp/package.json`.
+- Modify (scaffolding): `~/.claude/skills/mcp-vendor-scaffolding/SKILL.md`, `~/.claude/skills/mcp-server-fleet-ci-template/SKILL.md`.
+- Taskmaster: tracker tasks under this project root.
+
+---
+
+## Task 1: Write the codemod
+
+**Files:**
+- Create: `~/.claude/skills/ts6-fleet-migration/codemod.mjs`
+
+- [ ] **Step 1: Create the skill directory**
+
+Run:
+```bash
+mkdir -p ~/.claude/skills/ts6-fleet-migration
+```
+
+- [ ] **Step 2: Write the codemod script**
+
+Create `~/.claude/skills/ts6-fleet-migration/codemod.mjs`:
+```js
+#!/usr/bin/env node
+// ts6-codemod — make a WYRE MCP repo TypeScript 6-ready.
+// Idempotent + dialect-aware. Run from a repo root: node codemod.mjs [--dry-run]
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+
+const dry = process.argv.includes("--dry-run");
+const TS_VERSION = "^6.0.3";
+
+function patchTsconfig(path) {
+  if (!existsSync(path)) return { path, changed: false, reason: "missing" };
+  let json;
+  try { json = JSON.parse(readFileSync(path, "utf8")); }
+  catch { return { path, changed: false, reason: "UNPARSEABLE (JSONC/comments?) — hand-edit" }; }
+  json.compilerOptions = json.compilerOptions || {};
+  const t = json.compilerOptions.types;
+  if (Array.isArray(t) && t.includes("node")) return { path, changed: false, reason: "already has node" };
+  json.compilerOptions.types = Array.isArray(t) ? [...new Set([...t, "node"])] : ["node"];
+  if (!dry) writeFileSync(path, JSON.stringify(json, null, 2) + "\n");
+  return { path, changed: true };
+}
+
+function patchPackageJson(path) {
+  const json = JSON.parse(readFileSync(path, "utf8"));
+  const dd = json.devDependencies || {};
+  const dep = json.dependencies || {};
+  let changed = false;
+  if ("typescript" in dd && dd.typescript !== TS_VERSION) { dd.typescript = TS_VERSION; changed = true; }
+  else if ("typescript" in dep && dep.typescript !== TS_VERSION) { dep.typescript = TS_VERSION; changed = true; }
+  else if (!("typescript" in dd) && !("typescript" in dep)) return { path, changed: false, reason: "no typescript dep" };
+  if (changed && !dry) writeFileSync(path, JSON.stringify(json, null, 2) + "\n");
+  return { path, changed, reason: changed ? `typescript -> ${TS_VERSION}` : "already at target" };
+}
+
+console.log(dry ? "[dry-run]" : "[apply]");
+console.log("tsconfig:", patchTsconfig("tsconfig.json"));
+console.log("package:", patchPackageJson("package.json"));
+console.log("Next: npm install && npm run build && npm test && npm run lint && npm run typecheck");
+```
+
+- [ ] **Step 3: Self-test the codemod against a fixture (dry-run, both dialects)**
+
+Run:
+```bash
+cd /tmp && rm -rf ts6fix && mkdir -p ts6fix/A ts6fix/B
+# Dialect A (has lib, no types)
+printf '{\n  "compilerOptions": { "target": "ES2022", "lib": ["ES2022"] }\n}\n' > ts6fix/A/tsconfig.json
+printf '{\n  "devDependencies": { "typescript": "^5.9.3" }\n}\n' > ts6fix/A/package.json
+# Dialect B (bundler, no lib, no types)
+printf '{\n  "compilerOptions": { "module": "ESNext", "moduleResolution": "bundler" }\n}\n' > ts6fix/B/tsconfig.json
+printf '{\n  "devDependencies": { "typescript": "^5.5.0" }\n}\n' > ts6fix/B/package.json
+(cd ts6fix/A && node ~/.claude/skills/ts6-fleet-migration/codemod.mjs && cat tsconfig.json package.json)
+(cd ts6fix/B && node ~/.claude/skills/ts6-fleet-migration/codemod.mjs && cat tsconfig.json package.json)
+```
+Expected: both `tsconfig.json` files now contain `"types": ["node"]` (A keeps its `lib`; B gains `types` with no `lib`), both `package.json` show `typescript: "^6.0.3"`. Re-running prints `already has node` / `already at target` (idempotent).
+
+- [ ] **Step 4: Commit the codemod** (only if `~/.claude/skills` is a git repo; otherwise skip with a note)
+
+Run:
+```bash
+cd ~/.claude/skills && git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  && git add ts6-fleet-migration/codemod.mjs && git commit -m "feat(ts6): add fleet TS6 codemod" \
+  || echo "skills dir not a git repo — codemod saved, no commit"
+```
+
+---
+
+## Task 2: Canary 1 — itglue-mcp (Dialect A, has worker.ts)
+
+**Files:**
+- Modify: `tsconfig.json`, `package.json`, `.github/dependabot.yml`
+- Branch: `chore/ts6-migration` (already checked out in this worktree)
+
+- [ ] **Step 1: Confirm the bug reproduces (baseline failure)**
+
+Run from the itglue-mcp worktree:
+```bash
+npm install typescript@^6.0.3 >/dev/null 2>&1 && npm run build 2>&1 | tail -3
+```
+Expected: build FAILS with `Cannot find name 'process'/'fetch'/...`. (This is the regression the fix addresses.)
+
+- [ ] **Step 2: Apply the codemod**
+
+Run:
+```bash
+node ~/.claude/skills/ts6-fleet-migration/codemod.mjs
+git --no-pager diff tsconfig.json package.json
+```
+Expected: `tsconfig.json` gains `"types": ["node"]`; `package.json` `typescript` is `^6.0.3`.
+
+- [ ] **Step 3: Install + verify build now passes**
+
+Run:
+```bash
+npm install >/dev/null 2>&1 && npm run build 2>&1 | tail -3; echo "exit: ${PIPESTATUS[0]}"
+```
+Expected: build succeeds, exit 0.
+
+- [ ] **Step 4: Full verify (test + lint + typecheck)**
+
+Run:
+```bash
+npm test 2>&1 | grep -E "Tests "; npm run lint >/dev/null 2>&1 && echo "lint OK" || echo "lint FAIL"; npm run typecheck >/dev/null 2>&1 && echo "typecheck OK" || echo "typecheck FAIL"
+```
+Expected: `Tests 146 passed`, `lint OK`, `typecheck OK`. If any *additional* TS6 type errors appear, fix them minimally here and re-run.
+
+- [ ] **Step 5: Remove the Dependabot TS-major ignore (itglue carries it)**
+
+Edit `.github/dependabot.yml` — delete the `ignore:` block added for `typescript` semver-major (the repo is now on TS6, so future TS updates should flow). Verify:
+```bash
+grep -q "version-update:semver-major" .github/dependabot.yml && echo "STILL PRESENT — remove it" || echo "ignore removed OK"
+```
+
+- [ ] **Step 6: Commit + push + PR**
+
+Run:
+```bash
+git add tsconfig.json package.json package-lock.json .github/dependabot.yml
+git commit -m "build(deps-dev): adopt TypeScript 6
+
+Add compilerOptions.types: [node] so Node/web globals resolve under TS6
+(TS 6.0 stopped auto-including @types/node). Bump typescript ^6.0.3 and
+drop the Dependabot typescript-major ignore. Verified: build, 146 tests,
+lint, typecheck. First canary of the fleet TS6 migration."
+git push -u origin chore/ts6-migration
+gh pr create --repo wyre-technology/itglue-mcp --base main --head chore/ts6-migration \
+  --title "build(deps-dev): adopt TypeScript 6 (canary 1)" \
+  --body "First TS6 fleet-migration canary. Adds tsconfig types:[node] (restores Node/web globals dropped by TS6), bumps typescript ^6.0.3, removes the TS-major Dependabot ignore. Carries the migration spec + plan. Verified build/test/lint/typecheck locally."
+```
+Expected: PR created. Wait for CI green (build, tests Node 20/22, `assert`) before merge.
+
+---
+
+## Task 3: Canary 2 — huntress-mcp (Dialect B, bundler)
+
+**Files:**
+- Modify (in a fresh clone): `huntress-mcp/tsconfig.json`, `huntress-mcp/package.json`
+
+- [ ] **Step 1: Clone huntress-mcp to a scratch dir**
+
+Run:
+```bash
+cd /tmp && rm -rf huntress-mcp && gh repo clone wyre-technology/huntress-mcp && cd huntress-mcp
+git checkout -b chore/ts6-migration
+npm ci >/dev/null 2>&1 && echo "installed"
+```
+
+- [ ] **Step 2: Confirm baseline build passes on TS5, then reproduce TS6 failure**
+
+Run:
+```bash
+npm run build >/dev/null 2>&1 && echo "TS5 build OK"
+npm install typescript@^6.0.3 >/dev/null 2>&1 && npm run build 2>&1 | tail -3
+```
+Expected: TS5 build OK; TS6 build FAILS with missing-globals errors (confirms the bundler dialect breaks the same way).
+
+- [ ] **Step 3: Apply the codemod + verify**
+
+Run:
+```bash
+node ~/.claude/skills/ts6-fleet-migration/codemod.mjs
+git --no-pager diff tsconfig.json package.json
+npm install >/dev/null 2>&1 && npm run build 2>&1 | tail -3; echo "build exit: ${PIPESTATUS[0]}"
+npm test 2>&1 | tail -3
+npm run lint >/dev/null 2>&1 && echo "lint OK" || echo "lint FAIL (check if repo has lint script)"
+```
+Expected: `tsconfig.json` gains `"types": ["node"]` (no `lib` added); build exit 0; tests pass. Fix any additional TS6 errors minimally. If a script (lint/typecheck) doesn't exist in this repo, note it and skip.
+
+- [ ] **Step 4: Commit + push + PR**
+
+Run:
+```bash
+git add tsconfig.json package.json package-lock.json
+git commit -m "build(deps-dev): adopt TypeScript 6
+
+Add compilerOptions.types: [node] for TS6 global resolution; bump
+typescript ^6.0.3. Second canary (bundler tsconfig dialect) of the
+fleet TS6 migration. Verified build + tests."
+git push -u origin chore/ts6-migration
+gh pr create --repo wyre-technology/huntress-mcp --base main --head chore/ts6-migration \
+  --title "build(deps-dev): adopt TypeScript 6 (canary 2, bundler dialect)" \
+  --body "Second TS6 fleet-migration canary, proving the fix on the bundler tsconfig dialect. Adds types:[node], bumps typescript ^6.0.3. Verified build + tests locally."
+```
+Expected: PR created; wait for CI green before merge.
+
+---
+
+## Task 4: Author the `ts6-fleet-migration` skill
+
+**Files:**
+- Create: `~/.claude/skills/ts6-fleet-migration/SKILL.md`
+
+- [ ] **Step 1: Invoke skill-creator**
+
+Use the `skill-creator` skill to scaffold `ts6-fleet-migration`. Target directory `~/.claude/skills/ts6-fleet-migration/` (codemod.mjs already lives there).
+
+- [ ] **Step 2: Write SKILL.md content**
+
+The SKILL.md must contain, concretely (no placeholders):
+- **Trigger description:** "migrate a WYRE MCP repo (or the fleet) to TypeScript 6", "TS6 fleet migration", "fan out the TS6 codemod".
+- **The fix** (1 paragraph): TS6 dropped auto-`@types/node`; add `compilerOptions.types: ["node"]`; no DOM lib needed.
+- **Codemod usage:** `node ~/.claude/skills/ts6-fleet-migration/codemod.mjs [--dry-run]` from a repo root; idempotent; UNPARSEABLE result = hand-edit (JSONC).
+- **Per-repo verify checklist:** install → build → test → lint → typecheck; hand-fix extra TS6 errors; remove any Dependabot TS-major ignore.
+- **Subagent dispatch pattern:** one repo per subagent — clone/worktree, codemod, install, verify, on green open `build(deps-dev): adopt TypeScript 6` PR + tick tracker; on failure capture error class + mark blocked.
+- **In-scope list** (the ~45 TS repos) and **out-of-scope** (the 6 JS repos: datto-bcdr, datto-saas-protection, kaseya-bms, kaseya-vsa, spanning, unitrends).
+- **Dialect notes:** A (NodeNext+lib) vs B (bundler, no lib/types); both fixed identically by the codemod.
+- **Future fan-out:** dry-run triage across all repos first to classify green vs needs-handwork.
+
+- [ ] **Step 3: Verify the skill is discoverable**
+
+Run:
+```bash
+test -f ~/.claude/skills/ts6-fleet-migration/SKILL.md && head -5 ~/.claude/skills/ts6-fleet-migration/SKILL.md
+```
+Expected: SKILL.md exists with frontmatter (name + description).
+
+---
+
+## Task 5: Seed the Taskmaster tracker
+
+- [ ] **Step 1: Create one tracker task per in-scope repo**
+
+Using Taskmaster, create a parent task "TS6 fleet migration" and a subtask per in-scope repo (status pending), marking `itglue-mcp` and `huntress-mcp` done once their PRs merge. In-scope repos:
+
+```
+abnormal, action1, afkbot, alternative-payments, atera, autotask, auvik,
+avanan, avanan-legacy, blackpoint, blumira, brain, cipp, connectwise-automate,
+connectwise-manage, crewhu, datto-rmm, domotz, halopsa, hudu, huntress(done),
+immybot, iqms, ironscales, itglue(done), kaseya-quote-manager, knowbe4, liongard,
+mcp-gateway, mcpgw-cli, mimecast, ninjaone, pax8, proofpoint, qbo, rocketcyber,
+rootly, salesbuildr, salesforce, sentinelone, sherweb, spamtitan, superops,
+syncro, threatlocker, timezest, xero
+```
+(JS repos excluded: datto-bcdr, datto-saas-protection, kaseya-bms, kaseya-vsa, spanning, unitrends.)
+
+- [ ] **Step 2: Confirm the tracker lists all repos**
+
+Run Taskmaster `get_tasks` and verify the count of in-scope subtasks matches the list above.
+
+---
+
+## Task 6: Update scaffolding skills (born TS6-ready)
+
+**Files:**
+- Modify: `~/.claude/skills/mcp-vendor-scaffolding/SKILL.md`
+- Modify: `~/.claude/skills/mcp-server-fleet-ci-template/SKILL.md`
+
+- [ ] **Step 1: Bump the TS pin in the scaffolding skill**
+
+In `~/.claude/skills/mcp-vendor-scaffolding/SKILL.md`, change the pinned `"typescript": "^5.3.0"` to `"typescript": "^6.0.3"`.
+
+- [ ] **Step 2: Ensure the canonical tsconfig includes types:[node]**
+
+In the same skill, locate the tsconfig template/guidance and ensure `compilerOptions` includes `"types": ["node"]`. If the skill only references `tsconfig.json` structurally without a literal body, add an explicit note: "tsconfig must include `compilerOptions.types: ["node"]` for TS6."
+
+- [ ] **Step 3: Mirror into the fleet-ci-template skill**
+
+In `~/.claude/skills/mcp-server-fleet-ci-template/SKILL.md`, add/adjust any TS version reference to `^6.0.3` and note the `types: ["node"]` requirement.
+
+- [ ] **Step 4: Verify**
+
+Run:
+```bash
+grep -n "typescript" ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md | grep -i "6\."
+grep -n "types.*node" ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md || echo "ADD the types:[node] note"
+```
+Expected: TS pin shows 6.x; a `types: ["node"]` reference is present.
+
+- [ ] **Step 5: Commit (if skills dir is a git repo)**
+
+Run:
+```bash
+cd ~/.claude/skills && git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  && git add mcp-vendor-scaffolding/SKILL.md mcp-server-fleet-ci-template/SKILL.md ts6-fleet-migration/ \
+  && git commit -m "feat(scaffolding): TS6-ready template + ts6-fleet-migration skill" \
+  || echo "skills dir not a git repo — changes saved, no commit"
+```
+
+---
+
+## Done criteria
+
+- Both canary PRs merged and green (build, tests, `assert`).
+- `~/.claude/skills/ts6-fleet-migration/` holds a self-tested codemod + SKILL.md runbook.
+- Taskmaster tracker lists all in-scope repos with itglue + huntress marked done.
+- Scaffolding skills pin TS6 and require `types: ["node"]`.
+- No fleet-wide fan-out performed (deferred per spec).

--- a/docs/superpowers/specs/2026-06-08-ts6-fleet-migration-design.md
+++ b/docs/superpowers/specs/2026-06-08-ts6-fleet-migration-design.md
@@ -1,0 +1,119 @@
+# TypeScript 6 Fleet Migration — Capability Design
+
+**Date:** 2026-06-08
+**Status:** Approved (design)
+**Scope owner:** WYRE MCP fleet
+
+## Objective
+
+Establish a *proven, reusable capability* to migrate the WYRE MCP server fleet
+(~45 TypeScript repos) to TypeScript 6 — validated on two canaries that cover both
+tsconfig dialects, baked into the scaffolding skills, and encoded as an executable
+runbook + tracker.
+
+**This effort deliberately stops before the fleet-wide fan-out.** TypeScript 6.0 is
+brand new; we prove the recipe and build the tooling now, and pull the trigger
+across all repos later (the dry-run triage in "Future fan-out" is the recommended
+first step of that push).
+
+## Background — why this is needed
+
+TypeScript 6.0 stopped auto-including `@types/node`'s global declarations. Repos whose
+`tsconfig.json` relies on implicit `@types/*` inclusion lose `process`, `fetch`,
+`Response`, `Request`, `Headers`, `URL`, and `URLSearchParams`, so `tsc` fails with
+`Cannot find name '<global>'`. This was first hit on `itglue-mcp` while triaging
+Dependabot PR #33 (typescript 5.9.3 → 6.0.3), where TS6 was deferred and a Dependabot
+`ignore` for `typescript` semver-major was added so the PR would not keep reopening.
+
+**Confirmed fix (spike on `itglue-mcp`):** adding `"types": ["node"]` to
+`compilerOptions` restores all the missing globals under TS6. Verified with
+`lib: ["ES2022"]` only — **no `DOM`/`WebWorker` lib entry is required**, because
+`@types/node` declares the web-standard globals (`fetch`/`Response`/`URL`/…) that
+`worker.ts` uses.
+
+## In scope / out of scope
+
+**In scope:** ~45 TypeScript `*-mcp` repos plus `mcp-gateway` / `mcpgw-cli`.
+
+**Out of scope (JavaScript repos — no TS to bump):** `datto-bcdr-mcp`,
+`datto-saas-protection-mcp`, `kaseya-bms-mcp`, `kaseya-vsa-mcp`, `spanning-mcp`,
+`unitrends-mcp`.
+
+**Out of scope for this effort:** the fleet-wide fan-out (only the two canaries are
+migrated now).
+
+## Fleet is not uniform
+
+Sampling the fleet found at least two tsconfig dialects, so the migration is **not** a
+one-line sed across identical repos. The codemod and canaries must cover both:
+
+| Dialect | Shape | Examples |
+|---------|-------|----------|
+| A — NodeNext + explicit `lib` | `module/moduleResolution: NodeNext`, `lib: ["ES2022"]`, no `types` | itglue, halopsa, mcp-gateway; autotask is a CJS/ES2020 variant |
+| B — bundler, no lib/types | `module: ESNext`, `moduleResolution: bundler`, no `lib`, no `types` | huntress, rootly |
+
+TS versions also vary across the fleet (5.3 – 5.9), so the migration normalizes them.
+
+## The per-repo fix (recipe)
+
+1. Ensure `compilerOptions.types` includes `"node"` (create the array if absent — this
+   is the dialect-agnostic part).
+2. Bump `typescript` → `^6.0.x` (devDep); bump `@types/node` to current major if stale.
+3. Run `build` + `test` + `lint` + `typecheck`. Hand-fix any *additional* TS6
+   breakages (majors carry more than the globals change — this is per-repo and is why
+   we canary rather than blind-fan-out).
+4. Remove the Dependabot `typescript` semver-major `ignore` from `.github/dependabot.yml`
+   once the repo is on TS6 (so future TS minors/patches flow normally).
+
+## Deliverables (this effort)
+
+1. **Two canary PRs — merged & green:**
+   - `itglue-mcp` (Dialect A; has `worker.ts`, exercises web globals).
+   - `huntress-mcp` (Dialect B; `bundler` resolution, no `lib`/`types`).
+   Each must pass build + test + lint + typecheck locally **and** in CI (including the
+   `assert` eval job) before merge.
+2. **`ts6-fleet-migration` skill** (authored via skill-creator): houses the codemod
+   script, the subagent dispatch pattern, the per-repo verify checklist, and the
+   dialect notes — the durable, executable home for the capability.
+3. **Codemod script** (in the skill): a dependency-free Node script that is idempotent
+   and dialect-aware — parses `tsconfig.json`, ensures `types` includes `"node"`,
+   updates `package.json` `typescript`/`@types/node`, and touches nothing else.
+   Re-runnable safely; used by both the canaries and the eventual fan-out.
+4. **Taskmaster tracker** seeded with every in-scope repo (status pending/done/blocked)
+   so the eventual fan-out is trackable.
+5. **Updated scaffolding skills** (`mcp-vendor-scaffolding`, `mcp-server-fleet-ci-template`):
+   TS pin → `^6.0.0` and canonical tsconfig gains `types: ["node"]`, so new vendors are
+   born TS6-ready.
+
+## Subagent dispatch pattern (documented, not executed now)
+
+For the future fan-out, one repo per subagent:
+clone/worktree → run codemod → `npm i` → build/test/lint/typecheck → on green, open a
+`build(deps-dev): adopt TypeScript 6` PR and check off the tracker; on failure, capture
+the error class and mark the repo **blocked** for hand-fixing. Encoded in the skill so
+the later push is mechanical.
+
+## Verification & rollback
+
+- Canaries: green locally and in CI before merge.
+- Merge mechanics mirror the Dependabot cleanup (`main` requires one code-owner review,
+  `enforce_admins: false`). Admin-merge or tee-up for review — operator's choice at
+  merge time.
+- Rollback = revert the single per-repo PR; the codemod change is self-contained.
+
+## Risks
+
+- **Per-repo TS6 breakages beyond globals.** The globals fix is confirmed; stricter TS6
+  checks may surface additional type errors in individual repos. Mitigated by
+  canary-first + no blind fan-out.
+- **`worker.ts` / Cloudflare repos.** Spike showed `types: ["node"]` covers the
+  web-standard globals; still verify per repo since worker entries vary.
+- **TS 6.0 maturity.** It is brand new. The capability is built now; broad adoption is
+  intentionally deferred.
+
+## Future fan-out (not part of this effort)
+
+Recommended first step of the eventual push: run the codemod in `--dry-run` across all
+in-scope repos and `tsc` each, classifying *green* vs *needs-hand-fixing* to produce a
+fan-out cost report before committing. Then dispatch subagents per the pattern above,
+driven by the Taskmaster tracker.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^25.9.2",
         "eslint": "^10.4.1",
         "semantic-release": "^25.0.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
         "vitest": "^4.1.8"
       },
@@ -9114,9 +9114,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/node": "^25.9.2",
     "eslint": "^10.4.1",
     "semantic-release": "^25.0.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0",
     "vitest": "^4.1.8"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -13,8 +15,19 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts", "src/__tests__"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/__tests__"
+  ]
 }


### PR DESCRIPTION
First canary of the **TypeScript 6 fleet migration**.

### What
- Add `compilerOptions.types: ["node"]` to `tsconfig.json` — TS 6.0 stopped auto-including `@types/node`, dropping `process`/`fetch`/`Response`/`URL`; this restores them (no DOM lib needed).
- Bump `typescript` → `^6.0.3`.
- Remove the Dependabot `typescript` semver-major `ignore` (added when TS6 was deferred) now that the repo is on TS6.
- Applied via the new `ts6-fleet-migration` codemod.

Also includes the migration **spec** and **plan** docs under `docs/superpowers/`.

### Why
itglue-mcp is the Dialect-A canary (NodeNext + explicit `lib`, and it has a `worker.ts` exercising web globals). Proves the fix end-to-end before any fleet fan-out.

### Verification (local, TS 6.0.3)
- `build` ✓  ·  `test` 146 passed ✓  ·  `lint` ✓  ·  `typecheck` ✓

### Note for reviewers
The codemod reserializes `tsconfig.json` via `JSON.stringify`, which expanded the inline arrays — the only *semantic* change is the added `types` key + the TS bump. (Whether to make the codemod format-preserving before fan-out is an open decision captured in the plan.)