### PR TITLE
feat(tools): add IT Glue Locations tools (search/get/create/update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [Unreleased]
 
+### Added
+
+- **Locations tools:** `search_locations`, `get_location`, `create_location`, and
+  `update_location` for IT Glue's built-in Locations entity (physical
+  addresses/sites). Locations carry an organization's address fields and phone
+  number, which previously could not be retrieved through the server — the only
+  paths were `get_organization` (no address/phone) and `search_flexible_assets`
+  (custom assets only). `search_locations` mirrors `search_configurations`
+  (org-scoped, with the same "search by org name" elicitation fallback) and
+  filters by name, city, region, or country; the write tools accept the full
+  address/phone field set. API-key scope is sufficient — no JWT required.
+
 ### Fixed
 
 - **GitHub Packages auth:** `.npmrc` now reads a `read:packages` token from

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Provide the JWT in whichever way matches your deployment:
 - **search_configurations** - Search for configurations with filtering by organization, name, type, status, serial number, RMM ID, or PSA ID
 - **get_configuration** - Get a specific configuration by ID
 
+### Locations (Addresses/Sites)
+
+- **search_locations** - Search an organization's locations (built-in address/site records), filtering by organization, name, city, region, or country. Results include the address fields and phone number.
+- **get_location** - Get a specific location by ID, including its full address and phone number
+- **create_location** - Create a new location for an organization (requires `name`, typically `country_id`)
+- **update_location** - Update an existing location; only the fields you supply are changed
+
 ### Passwords
 
 - **search_passwords** - Search for password entries (metadata only, no actual passwords in results)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -22,9 +22,12 @@ vi.stubGlobal("fetch", mockFetch);
 import {
   buildFolderPickerOptions,
   createDocumentWithContent,
+  createMcpServer,
   ITGlueClient,
   parseFolderReference,
 } from "../index.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
 // Store original env vars
 const originalEnv = { ...process.env };
@@ -326,10 +329,15 @@ describe("Tool Definitions", () => {
     { name: "get_organization", requiredFields: ["id"], properties: ["id"] },
     { name: "search_configurations", requiredFields: [] as string[], properties: ["organization_id", "name", "configuration_type_id", "configuration_status_id", "serial_number", "rmm_id", "psa_id", "page_size", "page_number", "sort"] },
     { name: "get_configuration", requiredFields: ["id"], properties: ["id"] },
+    { name: "search_locations", requiredFields: [] as string[], properties: ["organization_id", "name", "city", "region_id", "country_id", "psa_id", "page_size", "page_number", "sort"] },
+    { name: "get_location", requiredFields: ["id"], properties: ["id"] },
+    { name: "create_location", requiredFields: ["organization_id", "name"], properties: ["organization_id", "name", "country_id", "region_id", "address_1", "address_2", "city", "postal_code", "phone", "fax", "notes", "primary"] },
+    { name: "update_location", requiredFields: ["organization_id", "id"], properties: ["organization_id", "id", "name", "country_id", "region_id", "address_1", "address_2", "city", "postal_code", "phone", "fax", "notes", "primary"] },
     { name: "search_passwords", requiredFields: [] as string[], properties: ["organization_id", "name", "password_category_id", "url", "username", "page_size", "page_number", "sort"] },
     { name: "get_password", requiredFields: ["id"], properties: ["id", "show_password"] },
     { name: "search_documents", requiredFields: ["organization_id"] as string[], properties: ["organization_id", "name", "page_size", "page_number", "sort"] },
     { name: "get_document", requiredFields: ["organization_id", "id"], properties: ["organization_id", "id"] },
+    { name: "list_document_folders", requiredFields: ["organization_id"], properties: ["organization_id", "name", "page_size", "page_number"] },
     { name: "create_document", requiredFields: ["organization_id", "name"], properties: ["organization_id", "name", "content"] },
     { name: "list_document_sections", requiredFields: ["document_id"], properties: ["document_id"] },
     { name: "create_document_section", requiredFields: ["document_id", "section_type", "content"], properties: ["document_id", "section_type", "content"] },
@@ -354,8 +362,8 @@ describe("Tool Definitions", () => {
     });
   });
 
-  it("should have 19 tools total", () => {
-    expect(tools.length).toBe(19);
+  it("should have 24 tools total", () => {
+    expect(tools.length).toBe(24);
   });
 });
 
@@ -1827,5 +1835,209 @@ describe("Health Check Response Format", () => {
     expect(parsed.status).toBe("ok");
     expect(parsed.region).toBe("us");
     expect(parsed.organizationTypesFound).toBe(5);
+  });
+});
+
+// Exercises the REAL MCP server end-to-end (ListTools + CallTool) over an
+// in-memory transport pair, so these tests cover the actual tool-handler
+// dispatch — not a re-implemented mock. fetch stays mocked underneath.
+describe("Locations tools (round-trip)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function connectLocationsClient(): Promise<Client> {
+    const server = createMcpServer({ apiKey: "test-api-key" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "locations-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  function firstText(result: unknown): string {
+    const r = result as { content?: Array<{ text?: string }> };
+    return r.content?.[0]?.text ?? "";
+  }
+
+  function isError(result: unknown): boolean {
+    return (result as { isError?: boolean }).isError === true;
+  }
+
+  it("registers all four locations tools", async () => {
+    const client = await connectLocationsClient();
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "search_locations",
+        "get_location",
+        "create_location",
+        "update_location",
+      ])
+    );
+  });
+
+  it("exposes 24 tools total", async () => {
+    const client = await connectLocationsClient();
+    const { tools } = await client.listTools();
+    expect(tools.length).toBe(24);
+  });
+
+  it("search_locations queries /locations filtered by organization and city", async () => {
+    const client = await connectLocationsClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(
+        createJsonApiResponse([
+          {
+            id: "5",
+            type: "locations",
+            attributes: {
+              name: "Primary Address",
+              phone: "423-555-0100",
+              city: "Chattanooga",
+              primary: true,
+            },
+          },
+        ])
+      )
+    );
+
+    const result = await client.callTool({
+      name: "search_locations",
+      arguments: { organization_id: 8637099, city: "Chattanooga" },
+    });
+
+    // Decode first: buildQueryString uses URLSearchParams, which percent-encodes
+    // the JSON:API filter brackets (filter%5Borganization-id%5D=...).
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).toContain("/locations?");
+    expect(url).toContain("filter[organization-id]=8637099");
+    expect(url).toContain("filter[city]=Chattanooga");
+    expect(firstText(result)).toContain("423-555-0100");
+  });
+
+  it("get_location fetches a single location by id", async () => {
+    const client = await connectLocationsClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        data: {
+          id: "5",
+          type: "locations",
+          attributes: { name: "HQ", phone: "423-555-0100" },
+        },
+      })
+    );
+
+    const result = await client.callTool({
+      name: "get_location",
+      arguments: { id: 5 },
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "https://api.itglue.com/locations/5"
+    );
+    expect(firstText(result)).toContain("423-555-0100");
+  });
+
+  it("get_location returns an error when id is missing", async () => {
+    const client = await connectLocationsClient();
+    const result = await client.callTool({
+      name: "get_location",
+      arguments: {},
+    });
+    expect(isError(result)).toBe(true);
+    expect(firstText(result).toLowerCase()).toContain("id is required");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("create_location posts attributes to the org locations relationship", async () => {
+    const client = await connectLocationsClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        data: {
+          id: "5",
+          type: "locations",
+          attributes: { name: "HQ", phone: "423-555-0100" },
+        },
+        meta: {},
+      })
+    );
+
+    const result = await client.callTool({
+      name: "create_location",
+      arguments: {
+        organization_id: 123,
+        name: "HQ",
+        phone: "423-555-0100",
+        country_id: 1,
+      },
+    });
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.itglue.com/organizations/123/relationships/locations"
+    );
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body as string)).toEqual({
+      data: {
+        type: "locations",
+        attributes: { name: "HQ", phone: "423-555-0100", country_id: 1 },
+      },
+    });
+    expect(firstText(result)).toContain("HQ");
+  });
+
+  it("create_location requires organization_id and name", async () => {
+    const client = await connectLocationsClient();
+    const result = await client.callTool({
+      name: "create_location",
+      arguments: { name: "HQ" },
+    });
+    expect(isError(result)).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("update_location patches only the supplied fields", async () => {
+    const client = await connectLocationsClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        data: {
+          id: "5",
+          type: "locations",
+          attributes: { phone: "423-555-9999" },
+        },
+        meta: {},
+      })
+    );
+
+    const result = await client.callTool({
+      name: "update_location",
+      arguments: { organization_id: 123, id: 5, phone: "423-555-9999" },
+    });
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.itglue.com/organizations/123/relationships/locations/5"
+    );
+    expect(options.method).toBe("PATCH");
+    expect(JSON.parse(options.body as string)).toEqual({
+      data: {
+        type: "locations",
+        attributes: { phone: "423-555-9999" },
+      },
+    });
+    expect(firstText(result)).toContain("423-555-9999");
+  });
+
+  it("update_location requires at least one field to change", async () => {
+    const client = await connectLocationsClient();
+    const result = await client.callTool({
+      name: "update_location",
+      arguments: { organization_id: 123, id: 5 },
+    });
+    expect(isError(result)).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -626,6 +626,193 @@ export function createMcpServer(credentialOverrides?: GatewayCredentials): Serve
           required: ["id"],
         },
       },
+      // Locations
+      {
+        name: "search_locations",
+        description:
+          "Search for locations (physical addresses/sites) of an organization in IT Glue. " +
+          "Each result includes the address fields and phone number. Locations are a built-in " +
+          "IT Glue entity (not a flexible asset), so use this rather than search_flexible_assets " +
+          "to look up an organization's address or phone.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            organization_id: {
+              type: "number",
+              description: "Filter by organization ID (recommended — locations are scoped to organizations)",
+            },
+            name: {
+              type: "string",
+              description: "Filter by location name (partial match)",
+            },
+            city: {
+              type: "string",
+              description: "Filter by city",
+            },
+            region_id: {
+              type: "number",
+              description: "Filter by region/state ID",
+            },
+            country_id: {
+              type: "number",
+              description: "Filter by country ID",
+            },
+            psa_id: {
+              type: "string",
+              description: "Filter by PSA integration ID",
+            },
+            page_size: {
+              type: "number",
+              description: "Number of results per page (max 1000, default 50)",
+            },
+            page_number: {
+              type: "number",
+              description: "Page number to retrieve (default 1)",
+            },
+            sort: {
+              type: "string",
+              description: "Sort field (prefix with - for descending, e.g., '-name')",
+            },
+          },
+          required: [],
+        },
+      },
+      {
+        name: "get_location",
+        description: "Get a specific location by ID from IT Glue, including its full address and phone number.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              description: "The location ID",
+            },
+          },
+          required: ["id"],
+        },
+      },
+      {
+        name: "create_location",
+        description:
+          "Create a new location (physical address/site) for an organization in IT Glue. " +
+          "IT Glue requires a name and typically a country_id for a location.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            organization_id: {
+              type: "number",
+              description: "Organization ID to create the location in",
+            },
+            name: {
+              type: "string",
+              description: "Location name/title",
+            },
+            country_id: {
+              type: "number",
+              description: "Country ID — IT Glue typically requires this when creating a location. Find country IDs in the IT Glue web UI.",
+            },
+            region_id: {
+              type: "number",
+              description: "Region/state ID",
+            },
+            address_1: {
+              type: "string",
+              description: "Address line 1",
+            },
+            address_2: {
+              type: "string",
+              description: "Address line 2",
+            },
+            city: {
+              type: "string",
+              description: "City",
+            },
+            postal_code: {
+              type: "string",
+              description: "Postal/ZIP code",
+            },
+            phone: {
+              type: "string",
+              description: "Phone number",
+            },
+            fax: {
+              type: "string",
+              description: "Fax number",
+            },
+            notes: {
+              type: "string",
+              description: "Free-text notes",
+            },
+            primary: {
+              type: "boolean",
+              description: "Whether this is the organization's primary location",
+            },
+          },
+          required: ["organization_id", "name"],
+        },
+      },
+      {
+        name: "update_location",
+        description: "Update an existing location in IT Glue. Only the fields you supply are changed.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            organization_id: {
+              type: "number",
+              description: "Organization ID that owns the location",
+            },
+            id: {
+              type: "string",
+              description: "The location ID to update",
+            },
+            name: {
+              type: "string",
+              description: "Location name/title",
+            },
+            country_id: {
+              type: "number",
+              description: "Country ID",
+            },
+            region_id: {
+              type: "number",
+              description: "Region/state ID",
+            },
+            address_1: {
+              type: "string",
+              description: "Address line 1",
+            },
+            address_2: {
+              type: "string",
+              description: "Address line 2",
+            },
+            city: {
+              type: "string",
+              description: "City",
+            },
+            postal_code: {
+              type: "string",
+              description: "Postal/ZIP code",
+            },
+            phone: {
+              type: "string",
+              description: "Phone number",
+            },
+            fax: {
+              type: "string",
+              description: "Fax number",
+            },
+            notes: {
+              type: "string",
+              description: "Free-text notes",
+            },
+            primary: {
+              type: "boolean",
+              description: "Whether this is the organization's primary location",
+            },
+          },
+          required: ["organization_id", "id"],
+        },
+      },
       // Passwords
       {
         name: "search_passwords",
@@ -1214,6 +1401,146 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               text: JSON.stringify(config, null, 2),
             },
           ],
+        };
+      }
+
+      // Locations
+      case "search_locations": {
+        const params: Record<string, unknown> = {};
+        const filter: Record<string, unknown> = {};
+
+        let locOrgId = args?.organization_id as number | undefined;
+
+        // If no organization_id, elicit an organization name search to find it
+        // (mirrors search_configurations / search_passwords).
+        if (!locOrgId) {
+          const orgSearch = await elicitText(
+            "Locations are easier to find when scoped to an organization. Which organization?",
+            "organization",
+            "Enter an organization name to search for"
+          );
+          if (orgSearch) {
+            const orgResult = await client.request("/organizations", {
+              filter: { name: orgSearch },
+              page: { size: 5, number: 1 },
+            });
+            const orgs = orgResult.data as Array<Record<string, unknown>>;
+            if (orgs.length === 1) {
+              locOrgId = Number(orgs[0].id);
+            } else if (orgs.length > 1) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Multiple organizations match "${orgSearch}". Please re-run with a specific organization_id:\n\n${JSON.stringify(orgs.map((o) => ({ id: o.id, name: o.name })), null, 2)}`,
+                  },
+                ],
+              };
+            }
+          }
+        }
+
+        if (locOrgId) filter.organizationId = locOrgId;
+        if (args?.name) filter.name = args.name;
+        if (args?.city) filter.city = args.city;
+        if (args?.region_id) filter.regionId = args.region_id;
+        if (args?.country_id) filter.countryId = args.country_id;
+        if (args?.psa_id) filter.psaId = args.psa_id;
+
+        if (Object.keys(filter).length > 0) params.filter = filter;
+        if (args?.sort) params.sort = args.sort;
+        params.page = {
+          size: (args?.page_size as number) || 50,
+          number: (args?.page_number as number) || 1,
+        };
+
+        const result = await client.request("/locations", params);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "get_location": {
+        if (!args?.id) {
+          return {
+            content: [{ type: "text", text: "Error: Location ID is required" }],
+            isError: true,
+          };
+        }
+        const location = await client.get(`/locations/${args.id}`);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(location, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "create_location": {
+        if (!args?.organization_id || !args?.name) {
+          return {
+            content: [{ type: "text", text: "Error: organization_id and name are required" }],
+            isError: true,
+          };
+        }
+        // IT Glue accepts snake_case attribute keys on write (same precedent as
+        // document creation). The organization is supplied via the relationship
+        // path, so it is not repeated in attributes.
+        const argv = args as Record<string, unknown>;
+        const attributes: Record<string, unknown> = { name: argv.name };
+        const writableFields = [
+          "country_id", "region_id", "address_1", "address_2",
+          "city", "postal_code", "phone", "fax", "notes", "primary",
+        ];
+        for (const field of writableFields) {
+          const value = argv[field];
+          if (value !== undefined && value !== null) attributes[field] = value;
+        }
+        const newLocation = await client.post(
+          `/organizations/${args.organization_id}/relationships/locations`,
+          { data: { type: "locations", attributes } }
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(newLocation, null, 2) }],
+        };
+      }
+
+      case "update_location": {
+        if (!args?.organization_id || !args?.id) {
+          return {
+            content: [{ type: "text", text: "Error: organization_id and id are required" }],
+            isError: true,
+          };
+        }
+        const argv = args as Record<string, unknown>;
+        const attributes: Record<string, unknown> = {};
+        const writableFields = [
+          "name", "country_id", "region_id", "address_1", "address_2",
+          "city", "postal_code", "phone", "fax", "notes", "primary",
+        ];
+        for (const field of writableFields) {
+          const value = argv[field];
+          if (value !== undefined && value !== null) attributes[field] = value;
+        }
+        if (Object.keys(attributes).length === 0) {
+          return {
+            content: [{ type: "text", text: "Error: provide at least one field to update (e.g. phone, address_1, city)" }],
+            isError: true,
+          };
+        }
+        const updatedLocation = await client.patch(
+          `/organizations/${args.organization_id}/relationships/locations/${args.id}`,
+          { data: { type: "locations", attributes } }
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(updatedLocation, null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Why

A customer testing the IT Glue connector through the Wyre gateway tried to read a location's **phone number** for an org (`Katalyst As-A-Client (Internal IT)`, org `8637099`) and hit a wall: IT Glue keeps an organization's address and phone on its built-in **Locations** entity, which this server had no tool for. The only existing paths were `get_organization` (no address/phone) and `search_flexible_assets` (custom assets only). Claude correctly diagnosed the gap and asked for a `search_locations` / `get_locations` tool — this PR adds it.

Because the gateway re-exposes whatever this server registers, shipping here + redeploying the container closes the gap with no gateway-repo change.

## What

Four new tools (API-key scope is sufficient — no JWT required):

| Tool | Endpoint | Notes |
|------|----------|-------|
| `search_locations` | `GET /locations` + filters | Mirrors `search_configurations`, incl. the "search by org name" elicitation fallback; filters by name/city/region/country |
| `get_location` | `GET /locations/:id` | Full record incl. address + **phone** |
| `create_location` | `POST /organizations/:org/relationships/locations` | Requires `name` (+ typically `country_id`) |
| `update_location` | `PATCH /organizations/:org/relationships/locations/:id` | Partial update; only supplied fields sent |

Scope was confirmed with the requester as **read + create/update** (no `delete_location`). Write tools carry no destructive annotation, consistent with `update_document_section`.

## Tests

Added a round-trip test block that drives the **real** MCP server (`createMcpServer` → `ListTools`/`CallTool` over an in-memory transport) rather than re-implementing the handler in the test — so the new tools are genuinely exercised, with `fetch` mocked underneath.

This also surfaced a pre-existing stale assertion: the duplicate "Tool Definitions" array was missing `list_document_folders` and asserted 19 tools when the server actually registered 20. Corrected the enumeration and count to the true **24** (20 + 4).

- `vitest run` → **160 passed**
- `tsc --noEmit`, `eslint src`, `tsc` (build), destructive-warnings lint → all clean

## Docs

- `README.md` — new **Locations** section under Available Tools
- `CHANGELOG.md` — `### Added` entry under Unreleased (semantic-release `feat:` → minor bump)