### PR TITLE
ci: re-pin release reusable to GITHUB_TOKEN npm-auth fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
       id-token: write
       security-events: write
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@a61021de876d0fd44dac777fa90f963fea25b0c3
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@a925b43adb22aa8885b8243e1056e6a42cdce4d1
     with:
       server-name: itglue-mcp
       image-name: ghcr.io/wyre-technology/itglue-mcp


### PR DESCRIPTION
Re-pins `mcp-server-release.yml` to wyre-technology/.github#32 (see wyre-technology/.github#33): the npm registry rejects custom App installation tokens for cross-repo package reads, which fails the Docker image build on the next real release — first seen on ninjaone-mcp v2.0.0. `ci:`-only commit; cuts no release. `mcp-server-deploy.yml` pins are unaffected (file unchanged between the SHAs).