### PR TITLE
fix(#134): let Desktop users set a JWT + stop reporting foldered orgs as empty

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,13 +16,14 @@
     "mcp_config": {
       "command": "node",
       "args": ["${__dirname}/dist/index.js"],
-      "env": { "ITGLUE_API_KEY": "${user_config.itglue_api_key}", "ITGLUE_REGION": "${user_config.itglue_region}", "MCP_TRANSPORT": "stdio" }
+      "env": { "ITGLUE_API_KEY": "${user_config.itglue_api_key}", "ITGLUE_REGION": "${user_config.itglue_region}", "ITGLUE_JWT": "${user_config.itglue_jwt}", "MCP_TRANSPORT": "stdio" }
     }
   },
   "tools_generated": true,
   "user_config": {
     "itglue_api_key": { "type": "string", "title": "IT Glue API Key", "description": "Your IT Glue API key", "sensitive": true, "required": true },
-    "itglue_region": { "type": "string", "title": "IT Glue Region", "description": "Region: us or eu (default: us)", "sensitive": false, "required": false }
+    "itglue_region": { "type": "string", "title": "IT Glue Region", "description": "Region: us or eu (default: us)", "sensitive": false, "required": false },
+    "itglue_jwt": { "type": "string", "title": "IT Glue JWT (optional)", "description": "User-session JWT for elevated-scope operations such as document folder navigation. IT Glue's API-key scope cannot enumerate document folders; supplying a JWT enables it. JWTs are short-lived (~2h) and must be refreshed manually — see the README for how to retrieve one.", "sensitive": true, "required": false }
   },
   "compatibility": { "platforms": ["darwin", "win32", "linux"], "runtimes": { "node": ">=18.0.0" }, "claude_desktop": ">=0.10.0" }
 }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -24,6 +24,7 @@ import {
   createDocumentWithContent,
   ITGlueClient,
   parseFolderReference,
+  rootLevelDocumentsNote,
 } from "../index.js";
 
 // Store original env vars
@@ -730,6 +731,34 @@ describe("Tool Handler Integration", () => {
       const json = (await response.json()) as JsonApiResponse;
 
       expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Security Policy");
+    });
+  });
+
+  // Regression tests for wyre-technology/msp-claude-plugins#134: an org-wide
+  // search_documents returns only ROOT-LEVEL documents (IT Glue API limitation),
+  // so the model must be told the listing is partial or it reports the truncated
+  // count as the org's total ("this org has 1 document" for an org with 1,100+).
+  describe("rootLevelDocumentsNote", () => {
+    it("returns null when a folder filter scopes the search (result is complete)", () => {
+      expect(
+        rootLevelDocumentsNote({ folderFiltered: true, haveJwt: false })
+      ).toBeNull();
+      expect(
+        rootLevelDocumentsNote({ folderFiltered: true, haveJwt: true })
+      ).toBeNull();
+    });
+
+    it("warns that the listing is root-level-only for an unscoped search", () => {
+      const note = rootLevelDocumentsNote({ folderFiltered: false, haveJwt: true });
+      expect(note).toContain("ROOT-LEVEL");
+      expect(note).toContain("meta.total-count");
+      expect(note).toContain("list_document_folders");
+    });
+
+    it("tells API-key-only callers that folder enumeration needs a JWT", () => {
+      const note = rootLevelDocumentsNote({ folderFiltered: false, haveJwt: false });
+      expect(note).toContain("ITGLUE_JWT");
+      expect(note).toContain("cannot be listed");
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export {
   buildFolderPickerOptions,
   createDocumentWithContent,
   parseFolderReference,
+  rootLevelDocumentsNote,
 } from "./mcp-server.js";
 export type { GatewayCredentials, ITGlueRegion } from "./mcp-server.js";
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -454,6 +454,36 @@ export function parseFolderReference(input: string | null | undefined): FolderRe
   return { kind: "invalid", input: trimmed };
 }
 
+/**
+ * Advisory note for `search_documents` results.
+ *
+ * IT Glue's `/organizations/:id/relationships/documents` endpoint returns only
+ * ROOT-LEVEL documents unless `filter[document_folder_id]` is supplied — and
+ * folder enumeration itself needs a JWT (see `list_document_folders`). So an
+ * org-wide search on a heavily-foldered org can return a handful of documents
+ * (or none) even when the org holds thousands. Without a caveat the model
+ * reports that truncated count as authoritative ("this org has 1 document").
+ *
+ * Returns a note to prepend to the result, or null when a folder filter was
+ * applied (in which case the result is complete for that folder's scope).
+ */
+export function rootLevelDocumentsNote(opts: {
+  folderFiltered: boolean;
+  haveJwt: boolean;
+}): string | null {
+  if (opts.folderFiltered) return null;
+  return (
+    "NOTE: IT Glue's documents endpoint returns only ROOT-LEVEL documents unless a specific " +
+    "folder is queried. Documents inside folders are NOT included here and are NOT reflected in " +
+    "meta.total-count — do not report this as the organization's complete document count. " +
+    (opts.haveJwt
+      ? "To include foldered documents, call list_document_folders, then re-run search_documents " +
+        "with document_folder_id for each folder."
+      : "Folder enumeration requires a JWT credential (ITGLUE_JWT); without it, foldered documents " +
+        "cannot be listed. See list_document_folders and the README.")
+  );
+}
+
 // Credential extraction from gateway headers
 export interface GatewayCredentials {
   apiKey?: string;
@@ -1328,11 +1358,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             `/organizations/${args.organization_id}/relationships/documents`,
             params
           );
+          const note = rootLevelDocumentsNote({
+            folderFiltered: Boolean(args?.document_folder_id),
+            haveJwt: Boolean(sessionJwt ?? credentials.jwt),
+          });
+          const body = JSON.stringify(result, null, 2);
           return {
             content: [
               {
                 type: "text",
-                text: JSON.stringify(result, null, 2),
+                text: note ? `${note}\n\n${body}` : body,
               },
             ],
           };


### PR DESCRIPTION
Addresses both symptoms reported in wyre-technology/msp-claude-plugins#134 — which share one root cause: **IT Glue's API-key scope can't see inside document folders.** Folder enumeration requires a short-lived user-session JWT.

## 1. Expose `ITGLUE_JWT` in the MCPB extension (`manifest.json`)

The reporter installed the `.mcpb` extension and correctly found there was **no field to supply a JWT** — `user_config` only exposed `itglue_api_key` and `itglue_region`, and hand-editing the Desktop config gets wiped. The server has read `process.env.ITGLUE_JWT` since #20, but the manifest never mapped a value into it, so packaged/Desktop users couldn't reach it at all. (This is the packaging gap that #55, Docker-focused, didn't cover.)

- Adds an optional, `sensitive` `itglue_jwt` field mapped to the `ITGLUE_JWT` env var.
- **Safe for API-key-only users:** an unset optional field substitutes as empty/absent, and the client treats a falsy JWT as absent — constructor guard (`if (!apiKey && !jwt) throw`) and `authHeaders()` (`if (this.jwt) …; return x-api-key`).

## 2. Stop `search_documents` from being reported as the org's total

The other symptom: *"the org shows 1 document when it has 1,100+."* `/organizations/:id/relationships/documents` returns **only root-level documents** unless `filter[document_folder_id]` is supplied ([confirmed against IT Glue's API docs](https://help.itglue.kaseya.com/help/Content/1-admin/it-glue-api/getting-started-with-the-it-glue-api.html); same limitation independently reported in [Junto-Platforms/itglue-mcp-server#3](https://github.com/Junto-Platforms/itglue-mcp-server/issues/3)). The tool dumped raw JSON, so the model reported the truncated count as authoritative.

- Adds `rootLevelDocumentsNote()` and prepends it to **unscoped** `search_documents` results: tells the model the listing is root-level-only, that `meta.total-count` excludes foldered docs, and how to reach them (`list_document_folders` + `document_folder_id`, JWT required).
- No note when a folder filter is applied (that result is complete for its scope).
- 3 unit tests cover the branches.

## Out of scope
- **JWT auto-acquisition/refresh** — the `spike/issue-55-jwt-auto-acquisition` work tracked in #55 (blocked on whether tenant MFA is TOTP vs push). This PR only restores the **manual** JWT path (~2h TTL, paste from browser; README walkthrough).

## Verification
`npm run build` (clean), `npm test` (149 pass, incl. 3 new), `npm run lint` (clean). Manifest validated as JSON + structurally identical to existing fields (CI runs `mcpb validate`).

Refs wyre-technology/msp-claude-plugins#134, wyre-technology/itglue-mcp#55