### PR TITLE
fix: restore MCPB pack-and-upload to the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,49 @@ jobs:
       image-name: ghcr.io/wyre-technology/itglue-mcp
     secrets: inherit
 
+  # The reusable pipeline does not pack or attach the Claude Desktop .mcpb
+  # bundle (dropped when the hand-rolled workflow was replaced in #61, which
+  # is why v1.13.0 shipped with no assets). Restore it here until the step
+  # is upstreamed into mcp-server-release.yml.
+  mcpb:
+    name: Pack and upload MCPB bundle
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release.outputs.tag_name }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Stamp released version into package.json
+        # semantic-release does not commit the version bump back to the repo,
+        # and pack-mcpb.cjs copies package.json's version into manifest.json.
+        # Without this stamp the bundle ships with a stale version (v1.12.0's
+        # bundle said 1.5.3).
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version
+      - name: Pack MCPB bundle
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm install -g @anthropic-ai/mcpb
+          npm run pack:mcpb
+      - name: Upload bundle to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release.outputs.tag_name }}
+        run: |
+          BUNDLE_NAME=$(node -p "require('./package.json').name.replace(/^@.*\\//, '')")
+          gh release upload "$TAG_NAME" "${BUNDLE_NAME}.mcpb" \
+            --repo "${{ github.repository }}" --clobber
+
   deploy:
     needs: release
     if: needs.release.outputs.released == 'true'


### PR DESCRIPTION
## Problem

The v1.13.0 release shipped with **zero assets** — users couldn't download `itglue-mcp.mcpb` for Claude Desktop (reported by @cmehubert in wyre-technology/msp-claude-plugins#134).

**Root cause:** #61 replaced the hand-rolled release workflow with a thin caller of the reusable `wyre-technology/.github/.github/workflows/mcp-server-release.yml`. The old workflow's docker job contained a "Pack and upload MCPB bundle" step; the reusable pipeline has no such step (verified at both the pinned SHA and current HEAD), so the asset silently stopped being attached. v1.13.0 was the first release cut through the reusable.

## Fix

Adds an `mcpb` job to `release.yml` that runs when a release is cut:

1. Checks out the release tag (`needs.release.outputs.tag_name`) so the bundle matches the release exactly
2. Stamps the released version into `package.json` before packing — semantic-release never commits the version bump, and `pack-mcpb.cjs` copies `package.json`'s version into `manifest.json`. This also fixes a latent bug: the v1.12.0 bundle's manifest said `1.5.3`
3. Runs `npm run pack:mcpb` and uploads via `gh release upload --clobber`

Untrusted-input hygiene: workflow outputs are passed to `run:` steps via `env:` rather than inline interpolation.

## Notes

- The v1.13.0 asset has already been built from the tag and uploaded manually ([itglue-mcp.mcpb](https://github.com/wyre-technology/itglue-mcp/releases/download/v1.13.0/itglue-mcp.mcpb), manifest verified: version 1.13.0, `itglue_jwt` user_config present); this PR prevents recurrence
- Longer term this step should be upstreamed into the reusable `mcp-server-release.yml` so the whole fleet gets it — this PR restores the behavior for itglue-mcp now
- `fix:` type means semantic-release will cut a patch release on merge, which will also exercise the new job end-to-end