### PR TITLE
feat: API-key-first document folder access with JWT fallback (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## [Unreleased]
 
+### Changed
+
+- **API-key-first document folder access (JWT now an optional fallback):**
+  ([#55](https://github.com/wyre-technology/itglue-mcp/issues/55),
+  [msp-claude-plugins#134](https://github.com/wyre-technology/msp-claude-plugins/issues/134))
+  - `search_documents` now defaults to a folder-inclusive listing when no
+    `document_folder_id` is supplied: it sends
+    `filter[document_folder_id]=null` (which returns ALL documents, foldered
+    ones included), retries with the `filter[document_folder_id][ne]=` form if
+    the tenant's API rejects that (400/422), and only then degrades to the
+    legacy root-only listing — keeping the root-level-only warning for that
+    case. Each returned document carries its `documentFolderId`, so folder
+    membership is visible in the results. Explicit `document_folder_id`
+    searches are unchanged.
+  - `list_document_folders` tries the API key first (organization-relationship
+    path, then the top-level `/document_folders?filter[organization_id]=` form
+    if that 404s — IT Glue's public Document Folders resource is rolling out
+    across tenants through 2026 and may be exposed either way). The JWT client
+    is now only a fallback for tenants whose API key is rejected (401/403/404),
+    with the existing 401 JWT-cache-clear behavior retained.
+  - `create_document`'s name-based folder picker uses the same API-key-first,
+    JWT-fallback enumeration; the URL/ID folder prompt remains the last resort.
+  - Tool descriptions, error messages, and the README no longer describe the
+    JWT as a requirement for folder operations — it is an optional fallback,
+    only needed if your tenant's API key can't access Document Folders yet. All
+    JWT plumbing (`ITGLUE_JWT`, `X-ITGlue-JWT`, runtime paste) is unchanged.
+- **Publishing:** releases now publish `@wyre-technology/itglue-mcp` to the GitHub
+  Packages npm registry (`npmPublish: true`; `publishConfig.registry` was already
+  set to `https://npm.pkg.github.com`).
+
 ### Added
 
 - **Locations tools:** `search_locations`, `get_location`, `create_location`, and
@@ -21,12 +51,6 @@
   packages) without a 401 from `npm.pkg.github.com`. Note: unlike the other Wyre
   MCP servers, this one has no private runtime SDK dependency, so the one-click
   deploy buttons were never affected by the build-time 401.
-
-### Changed
-
-- **Publishing:** releases now publish `@wyre-technology/itglue-mcp` to the GitHub
-  Packages npm registry (`npmPublish: true`; `publishConfig.registry` was already
-  set to `https://npm.pkg.github.com`).
 
 ## [1.5.3](https://github.com/wyre-technology/itglue-mcp/compare/v1.5.2...v1.5.3) (2026-04-07)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The server accepts credentials via environment variables:
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `ITGLUE_API_KEY` | Your IT Glue API key (format: ITG.xxx) | Yes (env mode) |
-| `ITGLUE_JWT` | A user-session JWT for elevated-scope operations such as listing document folders. See [JWT for document-folder operations](#jwt-for-document-folder-operations). | No |
+| `ITGLUE_JWT` | A user-session JWT used as an optional **fallback** for document-folder operations on tenants whose API key cannot access the Document Folders resource yet. See [JWT fallback for document-folder operations](#jwt-fallback-for-document-folder-operations). | No |
 | `ITGLUE_REGION` | API region: `us`, `eu`, or `au` (default: `us`) | No |
 | `ITGLUE_BASE_URL` | Override the IT Glue API base URL (advanced) | No |
 | `MCP_TRANSPORT` | Transport: `stdio` (local) or `http` (remote). Defaults to `stdio` when run via `npx`/`node`, and to `http` in the Docker image. | No |
@@ -58,14 +58,15 @@ The server accepts credentials via environment variables:
 
 Alternative: When `AUTH_MODE=gateway`, the MCP Gateway injects credentials per request via HTTP headers instead of environment variables. See [Remote Deployment](#remote-deployment-http-streamable).
 
-### JWT for document-folder operations
+### JWT fallback for document-folder operations
 
-A handful of operations need more than an API key. IT Glue gates **document folders** behind a user-session JWT — the API-key scope can read and create documents, but it cannot enumerate folder names. Tools affected:
+**A JWT is optional** — it is only needed if your tenant's API key can't access Document Folders yet. Every folder-related path tries your API key first:
 
-- `list_document_folders` — fails without a JWT.
-- `create_document` — works without a JWT (falls back to a URL/ID folder prompt), but only offers the friendlier name-based folder picker when a JWT is present.
+- `search_documents` — defaults to a folder-inclusive listing (`filter[document_folder_id]=null` returns all documents, foldered ones included; each result carries its `documentFolderId`). If the tenant's API rejects that filter, the server retries the `[ne]` filter form and finally degrades to the legacy root-only listing, saying so in the result. No JWT is involved at any layer.
+- `list_document_folders` — IT Glue's public (API-key) API now documents a Document Folders resource, which is rolling out across tenants through 2026. The server tries the API key first (on the organization-relationship path, then the top-level `/document_folders` path) and only falls back to a JWT if the key is rejected.
+- `create_document` — the name-based folder picker uses the same API-key-first enumeration, then a configured JWT; if neither can list folders, it prompts for a folder URL / sibling-document URL / numeric folder ID as the last resort.
 
-Provide the JWT in whichever way matches your deployment:
+If you do need the JWT fallback, provide it in whichever way matches your deployment:
 
 | Mode | How to supply the JWT |
 |------|-----------------------|
@@ -73,7 +74,7 @@ Provide the JWT in whichever way matches your deployment:
 | Remote gateway (`AUTH_MODE=gateway`) | Send the `X-ITGlue-JWT` request header. |
 | Interactive clients (Claude Desktop/Code) | Leave it unset — the server prompts you to paste a JWT on first use and caches it for the session. |
 
-> **Headless deployments (Docker, cloud):** there is no one to answer the interactive prompt, so you **must** set `ITGLUE_JWT` (env mode) or send `X-ITGlue-JWT` (gateway mode) for folder enumeration to work.
+> **Headless deployments (Docker, cloud):** there is no one to answer the interactive prompt, so if your tenant's API key cannot enumerate folders you must set `ITGLUE_JWT` (env mode) or send `X-ITGlue-JWT` (gateway mode) for folder enumeration to work.
 
 **Retrieving a JWT from your browser:**
 
@@ -82,7 +83,7 @@ Provide the JWT in whichever way matches your deployment:
 3. Click any request to `itg-api-*.itglue.com`.
 4. Copy the value of the `Authorization: Bearer <token>` request header — the `<token>` part is your JWT.
 
-> **Expiry:** IT Glue JWTs are short-lived (~2 hours). A JWT placed in `ITGLUE_JWT` on a long-running container will go stale and folder enumeration will start failing until it is refreshed. Interactive clients are simply re-prompted on expiry. API-key-only operations (everything except folder enumeration) are unaffected.
+> **Expiry:** IT Glue JWTs are short-lived (~2 hours). A JWT placed in `ITGLUE_JWT` on a long-running container will go stale and the JWT fallback will start failing until it is refreshed. Interactive clients are simply re-prompted on expiry. API-key operations are unaffected.
 
 ## Available Tools
 
@@ -110,8 +111,8 @@ Provide the JWT in whichever way matches your deployment:
 
 ### Documents
 
-- **search_documents** - Search for documents with filtering by organization or name
-- **list_document_folders** - List an organization's document folders (names and IDs). Requires a JWT — see [JWT for document-folder operations](#jwt-for-document-folder-operations)
+- **search_documents** - Search for documents with filtering by organization, name, or folder. Defaults to a folder-inclusive listing (each result carries its `documentFolderId`), degrading gracefully to a root-only listing on tenants whose API rejects the folder filter
+- **list_document_folders** - List an organization's document folders (names and IDs). Works with an API key on tenants where IT Glue exposes the Document Folders resource; falls back to a JWT otherwise — see [JWT fallback for document-folder operations](#jwt-fallback-for-document-folder-operations)
 
 ### Flexible Assets
 

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
   "user_config": {
     "itglue_api_key": { "type": "string", "title": "IT Glue API Key", "description": "Your IT Glue API key", "sensitive": true, "required": true },
     "itglue_region": { "type": "string", "title": "IT Glue Region", "description": "Region: us or eu (default: us)", "sensitive": false, "required": false },
-    "itglue_jwt": { "type": "string", "title": "IT Glue JWT (optional)", "description": "User-session JWT for elevated-scope operations such as document folder navigation. IT Glue's API-key scope cannot enumerate document folders; supplying a JWT enables it. JWTs are short-lived (~2h) and must be refreshed manually — see the README for how to retrieve one.", "sensitive": true, "required": false }
+    "itglue_jwt": { "type": "string", "title": "IT Glue JWT (optional)", "description": "Optional fallback for document-folder operations. Folder access is API-key-first (IT Glue is rolling out a public Document Folders resource across tenants in 2026); a JWT is only used if your tenant's API key cannot access folders yet. JWTs are short-lived (~2h) and must be refreshed manually — see the README for how to retrieve one.", "sensitive": true, "required": false }
   },
   "compatibility": { "platforms": ["darwin", "win32", "linux"], "runtimes": { "node": ">=18.0.0" }, "claude_desktop": ">=0.10.0" }
 }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -23,8 +23,11 @@ import {
   buildFolderPickerOptions,
   createDocumentWithContent,
   createMcpServer,
+  folderedDocumentsIncludedNote,
   ITGlueClient,
+  listDocumentFoldersViaApiKey,
   parseFolderReference,
+  requestDocumentsWithFolderDefault,
   rootLevelDocumentsNote,
 } from "../index.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -746,6 +749,8 @@ describe("Tool Handler Integration", () => {
   // search_documents returns only ROOT-LEVEL documents (IT Glue API limitation),
   // so the model must be told the listing is partial or it reports the truncated
   // count as the org's total ("this org has 1 document" for an org with 1,100+).
+  // Since issue #55 this note is only emitted when the folder-inclusive filter
+  // forms were rejected and the search degraded to the legacy root-only call.
   describe("rootLevelDocumentsNote", () => {
     it("returns null when a folder filter scopes the search (result is complete)", () => {
       expect(
@@ -763,10 +768,169 @@ describe("Tool Handler Integration", () => {
       expect(note).toContain("list_document_folders");
     });
 
-    it("tells API-key-only callers that folder enumeration needs a JWT", () => {
+    it("frames the JWT as an optional fallback (not a requirement) for API-key-only callers", () => {
       const note = rootLevelDocumentsNote({ folderFiltered: false, haveJwt: false });
       expect(note).toContain("ITGLUE_JWT");
-      expect(note).toContain("cannot be listed");
+      expect(note).toContain("fallback");
+      expect(note).not.toMatch(/requires a JWT/i);
+    });
+  });
+
+  describe("folderedDocumentsIncludedNote", () => {
+    it("tells the model foldered documents are included and how to read folder membership", () => {
+      const note = folderedDocumentsIncludedNote();
+      expect(note).toContain("includes documents inside folders");
+      expect(note).toContain("documentFolderId");
+    });
+  });
+
+  // Issue #55: search_documents defaults to a folder-INCLUSIVE listing
+  // (filter[document_folder_id]=null returns ALL documents), degrading through
+  // the [ne] filter form down to the legacy root-only call when the tenant's
+  // API rejects the filter.
+  describe("requestDocumentsWithFolderDefault", () => {
+    function newClient(): ITGlueClient {
+      return new ITGlueClient({ apiKey: "test-api-key", region: "us" });
+    }
+
+    function decodedUrl(callIndex: number): string {
+      return decodeURIComponent(mockFetch.mock.calls[callIndex][0] as string);
+    }
+
+    it("sends filter[document_folder_id]=null on the first attempt", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(createJsonApiResponse([])));
+
+      const { attempt } = await requestDocumentsWithFolderDefault(newClient(), 123, {
+        page: { size: 50, number: 1 },
+      });
+
+      expect(attempt).toBe("null-filter");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(decodedUrl(0)).toContain("/organizations/123/relationships/documents");
+      expect(decodedUrl(0)).toContain("filter[document_folder_id]=null");
+    });
+
+    it("preserves caller filters (e.g. name) alongside the folder default", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(createJsonApiResponse([])));
+
+      await requestDocumentsWithFolderDefault(newClient(), 123, {
+        filter: { name: "Runbook" },
+        page: { size: 50, number: 1 },
+      });
+
+      expect(decodedUrl(0)).toContain("filter[name]=Runbook");
+      expect(decodedUrl(0)).toContain("filter[document_folder_id]=null");
+    });
+
+    it("retries with filter[document_folder_id][ne]= when the null form is rejected (400)", async () => {
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(400, "bad filter"))
+        .mockResolvedValueOnce(createMockResponse(createJsonApiResponse([])));
+
+      const { attempt } = await requestDocumentsWithFolderDefault(newClient(), 123, {
+        page: { size: 50, number: 1 },
+      });
+
+      expect(attempt).toBe("ne-filter");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(decodedUrl(1)).toContain("filter[document_folder_id][ne]=");
+    });
+
+    it("falls back to the unfiltered (root-only) call when both filter forms are rejected", async () => {
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(400, "bad filter"))
+        .mockResolvedValueOnce(createErrorResponse(422, "unprocessable"))
+        .mockResolvedValueOnce(createMockResponse(createJsonApiResponse([])));
+
+      const { attempt } = await requestDocumentsWithFolderDefault(newClient(), 123, {
+        page: { size: 50, number: 1 },
+      });
+
+      expect(attempt).toBe("unfiltered");
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(decodedUrl(2)).not.toContain("document_folder_id");
+    });
+
+    it("propagates non-filter errors (404, 500) without degrading", async () => {
+      mockFetch.mockResolvedValueOnce(createErrorResponse(404, "Not Found"));
+
+      await expect(
+        requestDocumentsWithFolderDefault(newClient(), 123, {})
+      ).rejects.toThrow(/404/);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // Issue #55: folder enumeration is API-key-first. IT Glue's public API now
+  // documents a Document Folders resource (rolling out across tenants), so the
+  // JWT becomes a fallback rather than a requirement.
+  describe("listDocumentFoldersViaApiKey", () => {
+    function newClient(): ITGlueClient {
+      return new ITGlueClient({ apiKey: "test-api-key", region: "us" });
+    }
+
+    it("returns folders from the organization relationship path", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            { id: "10", type: "document-folders", attributes: { name: "Runbooks" } },
+          ])
+        )
+      );
+
+      const result = await listDocumentFoldersViaApiKey(newClient(), 123, {});
+
+      expect(result).not.toBeNull();
+      expect((result!.data[0] as { name: string }).name).toBe("Runbooks");
+      expect(mockFetch.mock.calls[0][0]).toContain(
+        "/organizations/123/relationships/document_folders"
+      );
+    });
+
+    it("tries the top-level /document_folders form when the relationship path 404s", async () => {
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(404, "Not Found"))
+        .mockResolvedValueOnce(
+          createMockResponse(
+            createJsonApiResponse([
+              { id: "10", type: "document-folders", attributes: { name: "Runbooks" } },
+            ])
+          )
+        );
+
+      const result = await listDocumentFoldersViaApiKey(newClient(), 123, {});
+
+      expect(result).not.toBeNull();
+      const secondUrl = decodeURIComponent(mockFetch.mock.calls[1][0] as string);
+      expect(secondUrl).toContain("/document_folders?");
+      expect(secondUrl).toContain("filter[organization_id]=123");
+    });
+
+    it("returns null (JWT-fallback signal) when the API key is rejected with 403", async () => {
+      mockFetch.mockResolvedValueOnce(createErrorResponse(403, "Forbidden"));
+
+      const result = await listDocumentFoldersViaApiKey(newClient(), 123, {});
+
+      expect(result).toBeNull();
+      // 403 means the key is rejected outright — no point probing the top-level path.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null when both paths 404 (resource not exposed on this tenant)", async () => {
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(404, "Not Found"))
+        .mockResolvedValueOnce(createErrorResponse(404, "Not Found"));
+
+      const result = await listDocumentFoldersViaApiKey(newClient(), 123, {});
+
+      expect(result).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("propagates unexpected errors (500) instead of silently falling back", async () => {
+      mockFetch.mockResolvedValueOnce(createErrorResponse(500, "boom"));
+
+      await expect(listDocumentFoldersViaApiKey(newClient(), 123, {})).rejects.toThrow(/500/);
     });
   });
 
@@ -2068,5 +2232,352 @@ describe("Locations tools (round-trip)", () => {
     });
     expect(isError(result)).toBe(true);
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// Issue #55 round-trip coverage: exercises the REAL MCP server (CallTool) over
+// an in-memory transport pair so the API-key-first / JWT-fallback ordering in
+// the actual handlers is what's under test. fetch stays mocked underneath.
+describe("Document folder access (API-key-first, round-trip)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function connectClient(credentials: {
+    apiKey?: string;
+    jwt?: string;
+  }): Promise<Client> {
+    const server = createMcpServer(credentials);
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "folders-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  function firstText(result: unknown): string {
+    const r = result as { content?: Array<{ text?: string }> };
+    return r.content?.[0]?.text ?? "";
+  }
+
+  function isError(result: unknown): boolean {
+    return (result as { isError?: boolean }).isError === true;
+  }
+
+  function decodedUrl(callIndex: number): string {
+    return decodeURIComponent(mockFetch.mock.calls[callIndex][0] as string);
+  }
+
+  function headersOf(callIndex: number): Record<string, string> {
+    return (mockFetch.mock.calls[callIndex][1] as RequestInit)
+      .headers as Record<string, string>;
+  }
+
+  describe("search_documents", () => {
+    it("defaults to filter[document_folder_id]=null and surfaces each doc's folder id", async () => {
+      const client = await connectClient({ apiKey: "test-api-key" });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            {
+              id: "1",
+              type: "documents",
+              attributes: { name: "Foldered Doc", "document-folder-id": 42 },
+            },
+            {
+              id: "2",
+              type: "documents",
+              attributes: { name: "Root Doc", "document-folder-id": null },
+            },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "search_documents",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(decodedUrl(0)).toContain("filter[document_folder_id]=null");
+      const text = firstText(result);
+      expect(text).toContain("includes documents inside folders");
+      expect(text).not.toContain("ROOT-LEVEL");
+      // Folder membership is surfaced on each returned document.
+      expect(text).toContain('"documentFolderId": 42');
+    });
+
+    it("keeps exact current behavior for an explicit document_folder_id", async () => {
+      const client = await connectClient({ apiKey: "test-api-key" });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            { id: "1", type: "documents", attributes: { name: "Doc" } },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "search_documents",
+        arguments: { organization_id: 123, document_folder_id: 42 },
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(decodedUrl(0)).toContain("filter[document-folder-id]=42");
+      expect(decodedUrl(0)).not.toContain("filter[document_folder_id]=null");
+      expect(firstText(result)).not.toContain("NOTE:");
+    });
+
+    it("degrades 400 → [ne] filter and still reports foldered docs included", async () => {
+      const client = await connectClient({ apiKey: "test-api-key" });
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(400, "bad filter"))
+        .mockResolvedValueOnce(
+          createMockResponse(
+            createJsonApiResponse([
+              { id: "1", type: "documents", attributes: { name: "Doc" } },
+            ])
+          )
+        );
+
+      const result = await client.callTool({
+        name: "search_documents",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(decodedUrl(1)).toContain("filter[document_folder_id][ne]=");
+      expect(firstText(result)).toContain("includes documents inside folders");
+    });
+
+    it("degrades 400 → 422 → unfiltered and keeps the root-level-only warning", async () => {
+      const client = await connectClient({ apiKey: "test-api-key" });
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(400, "bad filter"))
+        .mockResolvedValueOnce(createErrorResponse(422, "unprocessable"))
+        .mockResolvedValueOnce(
+          createMockResponse(
+            createJsonApiResponse([
+              { id: "1", type: "documents", attributes: { name: "Root Doc" } },
+            ])
+          )
+        );
+
+      const result = await client.callTool({
+        name: "search_documents",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(decodedUrl(2)).not.toContain("document_folder_id");
+      const text = firstText(result);
+      expect(text).toContain("ROOT-LEVEL");
+      expect(text).toContain("meta.total-count");
+    });
+
+    it("still maps a 404 to the Documents-module-missing message (no degradation)", async () => {
+      const client = await connectClient({ apiKey: "test-api-key" });
+      mockFetch.mockResolvedValueOnce(createErrorResponse(404, "Not Found"));
+
+      const result = await client.callTool({
+        name: "search_documents",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("Documents module");
+    });
+  });
+
+  describe("list_document_folders", () => {
+    it("succeeds with the API key alone (no JWT involved)", async () => {
+      const client = await connectClient({ apiKey: "test-api-key" });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            { id: "10", type: "document-folders", attributes: { name: "Runbooks" } },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "list_document_folders",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(isError(result)).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(decodedUrl(0)).toContain(
+        "/organizations/123/relationships/document_folders"
+      );
+      expect(headersOf(0)["x-api-key"]).toBe("test-api-key");
+      expect(headersOf(0)["Authorization"]).toBeUndefined();
+      expect(firstText(result)).toContain("Runbooks");
+    });
+
+    it("prefers the API key even when a JWT is also configured", async () => {
+      const client = await connectClient({ apiKey: "test-api-key", jwt: "test-jwt" });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            { id: "10", type: "document-folders", attributes: { name: "Runbooks" } },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "list_document_folders",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(isError(result)).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(headersOf(0)["x-api-key"]).toBe("test-api-key");
+      expect(headersOf(0)["Authorization"]).toBeUndefined();
+    });
+
+    it("falls back to the top-level /document_folders path when the relationship path 404s", async () => {
+      const client = await connectClient({ apiKey: "test-api-key" });
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(404, "Not Found"))
+        .mockResolvedValueOnce(
+          createMockResponse(
+            createJsonApiResponse([
+              { id: "10", type: "document-folders", attributes: { name: "Runbooks" } },
+            ])
+          )
+        );
+
+      const result = await client.callTool({
+        name: "list_document_folders",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(isError(result)).toBe(false);
+      expect(decodedUrl(1)).toContain("/document_folders?");
+      expect(decodedUrl(1)).toContain("filter[organization_id]=123");
+    });
+
+    it("falls back to the configured JWT when the API key is rejected with 403", async () => {
+      const client = await connectClient({ apiKey: "test-api-key", jwt: "test-jwt" });
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(403, "Forbidden"))
+        .mockResolvedValueOnce(
+          createMockResponse(
+            createJsonApiResponse([
+              { id: "10", type: "document-folders", attributes: { name: "Runbooks" } },
+            ])
+          )
+        );
+
+      const result = await client.callTool({
+        name: "list_document_folders",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(isError(result)).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(headersOf(0)["x-api-key"]).toBe("test-api-key");
+      expect(headersOf(1)["Authorization"]).toBe("Bearer test-jwt");
+      expect(firstText(result)).toContain("Runbooks");
+    });
+
+    it("returns an actionable error when the API key is rejected and no JWT is available", async () => {
+      // The in-memory test client does not support elicitation, so the JWT
+      // prompt yields nothing — the neither-credential-works path.
+      const client = await connectClient({ apiKey: "test-api-key" });
+      mockFetch.mockResolvedValueOnce(createErrorResponse(403, "Forbidden"));
+
+      const result = await client.callTool({
+        name: "list_document_folders",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(isError(result)).toBe(true);
+      const text = firstText(result);
+      expect(text).toContain("Document Folders");
+      expect(text).toContain("ITGLUE_JWT");
+      expect(text).toContain("fallback");
+    });
+
+    it("clears the cached JWT when IT Glue rejects it with 401 (existing behavior)", async () => {
+      const client = await connectClient({ apiKey: "test-api-key", jwt: "stale-jwt" });
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(403, "Forbidden")) // API key
+        .mockResolvedValueOnce(createErrorResponse(401, "Unauthorized")); // stale JWT
+
+      const result = await client.callTool({
+        name: "list_document_folders",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("expired");
+    });
+  });
+
+  describe("create_document folder picker", () => {
+    it("enumerates folders with the API key first", async () => {
+      const client = await connectClient({ apiKey: "test-api-key", jwt: "test-jwt" });
+      mockFetch
+        .mockResolvedValueOnce(
+          createMockResponse(
+            createJsonApiResponse([
+              { id: "10", type: "document-folders", attributes: { name: "Runbooks" } },
+            ])
+          )
+        )
+        // Picker elicitation is unsupported by the test client → folderId stays
+        // undefined → the document is created at the root.
+        .mockResolvedValueOnce(
+          createMockResponse({
+            data: { id: "99", type: "documents", attributes: { name: "New Doc" } },
+          })
+        );
+
+      const result = await client.callTool({
+        name: "create_document",
+        arguments: { organization_id: 123, name: "New Doc" },
+      });
+
+      expect(isError(result)).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // Folder enumeration used the API key, not the configured JWT.
+      expect(decodedUrl(0)).toContain(
+        "/organizations/123/relationships/document_folders"
+      );
+      expect(headersOf(0)["x-api-key"]).toBe("test-api-key");
+      expect(headersOf(0)["Authorization"]).toBeUndefined();
+      expect(decodedUrl(1)).toContain("/organizations/123/relationships/documents");
+    });
+
+    it("falls back to the configured JWT for folder enumeration when the API key is rejected", async () => {
+      const client = await connectClient({ apiKey: "test-api-key", jwt: "test-jwt" });
+      mockFetch
+        .mockResolvedValueOnce(createErrorResponse(403, "Forbidden")) // API key
+        .mockResolvedValueOnce(
+          createMockResponse(
+            createJsonApiResponse([
+              { id: "10", type: "document-folders", attributes: { name: "Runbooks" } },
+            ])
+          )
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({
+            data: { id: "99", type: "documents", attributes: { name: "New Doc" } },
+          })
+        );
+
+      const result = await client.callTool({
+        name: "create_document",
+        arguments: { organization_id: 123, name: "New Doc" },
+      });
+
+      expect(isError(result)).toBe(false);
+      expect(headersOf(0)["x-api-key"]).toBe("test-api-key");
+      expect(headersOf(1)["Authorization"]).toBe("Bearer test-jwt");
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,17 @@ export {
   ITGlueClient,
   buildFolderPickerOptions,
   createDocumentWithContent,
+  folderedDocumentsIncludedNote,
+  listDocumentFoldersViaApiKey,
   parseFolderReference,
+  requestDocumentsWithFolderDefault,
   rootLevelDocumentsNote,
 } from "./mcp-server.js";
-export type { GatewayCredentials, ITGlueRegion } from "./mcp-server.js";
+export type {
+  DocumentSearchAttempt,
+  GatewayCredentials,
+  ITGlueRegion,
+} from "./mcp-server.js";
 
 /**
  * Start with stdio transport (default for local/CLI usage)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -98,12 +98,28 @@ function deserializeResource(resource: JsonApiResource): Record<string, unknown>
 function buildFilterParams(filter: Record<string, unknown>): Record<string, string> {
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(filter)) {
-    if (value !== undefined && value !== null) {
-      const kebabKey = camelToKebab(key);
+    if (value === undefined || value === null) continue;
+    const kebabKey = camelToKebab(key);
+    if (typeof value === "object" && !Array.isArray(value)) {
+      // JSON:API filter operator form, e.g. { ne: "" } → filter[key][ne]=
+      for (const [op, opValue] of Object.entries(value as Record<string, unknown>)) {
+        result[`${kebabKey}][${op}`] = String(opValue ?? "");
+      }
+    } else {
       result[kebabKey] = String(value);
     }
   }
   return result;
+}
+
+/**
+ * Extract the HTTP status from an ITGlueClient error message
+ * ("IT Glue API error (404): ..."), or null for non-HTTP errors.
+ */
+function apiErrorStatus(err: unknown): number | null {
+  const msg = err instanceof Error ? err.message : String(err);
+  const match = msg.match(/IT Glue API error \((\d{3})\)/);
+  return match ? Number(match[1]) : null;
 }
 
 // Simple IT Glue client
@@ -365,11 +381,11 @@ export async function createDocumentWithContent(
 }
 
 /**
- * Parse a folder reference supplied by the user. Folder *names* are not
- * reachable with API-key auth (IT Glue gates `/document_folders` behind a
- * user-session JWT — see the README for the JWT escape hatch). So the
- * elicitation path accepts inputs the user can copy out of their browser
- * tab while looking at the folder they want:
+ * Parse a folder reference supplied by the user. This is the last-resort
+ * folder prompt for when folder *names* cannot be enumerated — i.e. the
+ * tenant's API key does not (yet) expose the Document Folders resource and no
+ * JWT fallback is available (see the README). It accepts inputs the user can
+ * copy out of their browser tab while looking at the folder they want:
  *
  *   - empty / whitespace → root
  *   - bare numeric id    → folder
@@ -385,8 +401,8 @@ export type FolderReference =
   | { kind: "invalid"; input: string };
 
 /**
- * IT Glue document folder resource shape (subset used by the JWT-required
- * picker path). Folders are nested via `parent-id` (kebab) on the wire; the
+ * IT Glue document folder resource shape (subset used by the folder-picker
+ * path). Folders are nested via `parent-id` (kebab) on the wire; the
  * helper also accepts `parent_id` defensively.
  */
 export interface DocumentFolderResource {
@@ -458,11 +474,13 @@ export function parseFolderReference(input: string | null | undefined): FolderRe
  * Advisory note for `search_documents` results.
  *
  * IT Glue's `/organizations/:id/relationships/documents` endpoint returns only
- * ROOT-LEVEL documents unless `filter[document_folder_id]` is supplied — and
- * folder enumeration itself needs a JWT (see `list_document_folders`). So an
- * org-wide search on a heavily-foldered org can return a handful of documents
- * (or none) even when the org holds thousands. Without a caveat the model
- * reports that truncated count as authoritative ("this org has 1 document").
+ * ROOT-LEVEL documents unless a `filter[document_folder_id]` is supplied. The
+ * handler defaults to `filter[document_folder_id]=null` (which — despite the
+ * name — returns ALL documents including foldered ones) so this note is only
+ * emitted when the tenant's API rejected both folder-inclusive filter forms
+ * and the search degraded to the legacy root-only listing. Without the caveat
+ * the model reports that truncated count as authoritative ("this org has 1
+ * document" for an org holding thousands).
  *
  * Returns a note to prepend to the result, or null when a folder filter was
  * applied (in which case the result is complete for that folder's scope).
@@ -473,15 +491,135 @@ export function rootLevelDocumentsNote(opts: {
 }): string | null {
   if (opts.folderFiltered) return null;
   return (
-    "NOTE: IT Glue's documents endpoint returns only ROOT-LEVEL documents unless a specific " +
-    "folder is queried. Documents inside folders are NOT included here and are NOT reflected in " +
-    "meta.total-count — do not report this as the organization's complete document count. " +
+    "NOTE: this listing contains only ROOT-LEVEL documents. The folder-inclusive filter forms " +
+    "(filter[document_folder_id]=null and its [ne] variant) were rejected by this IT Glue tenant's " +
+    "API, so the search degraded to the legacy root-only listing. Documents inside folders are NOT " +
+    "included here and are NOT reflected in meta.total-count — do not report this as the " +
+    "organization's complete document count. To include foldered documents, call " +
+    "list_document_folders, then re-run search_documents with document_folder_id for each folder." +
     (opts.haveJwt
-      ? "To include foldered documents, call list_document_folders, then re-run search_documents " +
-        "with document_folder_id for each folder."
-      : "Folder enumeration requires a JWT credential (ITGLUE_JWT); without it, foldered documents " +
-        "cannot be listed. See list_document_folders and the README.")
+      ? ""
+      : " list_document_folders works with an API key on tenants where IT Glue exposes the " +
+        "Document Folders resource; a JWT (ITGLUE_JWT) is only needed as a fallback if it does not. " +
+        "See the README.")
   );
+}
+
+/**
+ * Advisory note prepended to `search_documents` results when the
+ * folder-inclusive listing succeeded: tells the model how to read folder
+ * membership off each document instead of assuming a flat listing.
+ */
+export function folderedDocumentsIncludedNote(): string {
+  return (
+    "NOTE: this listing includes documents inside folders. Each document's documentFolderId " +
+    "identifies its folder (null/absent = organization root). Use list_document_folders to " +
+    "resolve folder names."
+  );
+}
+
+/** Which filter form ultimately produced a `search_documents` listing. */
+export type DocumentSearchAttempt = "null-filter" | "ne-filter" | "unfiltered";
+
+/**
+ * Fetch an organization's documents, defaulting to a folder-INCLUSIVE listing.
+ *
+ * IT Glue's documents relationship endpoint returns only root-level documents
+ * unless `filter[document_folder_id]` is supplied. Passing the literal value
+ * `null` returns ALL documents (foldered ones included); the
+ * `filter[document_folder_id][ne]=` form is a community-verified alternative.
+ * Layered degradation, so tenants whose API rejects either form still work:
+ *
+ *   1. `filter[document_folder_id]=null`   → all documents
+ *   2. `filter[document_folder_id][ne]=`   → all documents (alternate form)
+ *   3. unfiltered                          → root-level only (legacy)
+ *
+ * Only a 400/422 (filter rejected) triggers the next layer — anything else
+ * (401/404/5xx) propagates to the caller unchanged.
+ */
+export async function requestDocumentsWithFolderDefault(
+  client: ITGlueClient,
+  organizationId: number | string,
+  params: Record<string, unknown>
+): Promise<{
+  result: { data: unknown[]; meta: PaginationMeta };
+  attempt: DocumentSearchAttempt;
+}> {
+  const path = `/organizations/${organizationId}/relationships/documents`;
+  const withFolderFilter = (folderFilter: Record<string, unknown>) => ({
+    ...params,
+    filter: { ...((params.filter as Record<string, unknown>) ?? {}), ...folderFilter },
+  });
+  const filterRejected = (err: unknown) => {
+    const status = apiErrorStatus(err);
+    return status === 400 || status === 422;
+  };
+
+  try {
+    const result = await client.request(path, withFolderFilter({ document_folder_id: "null" }));
+    return { result, attempt: "null-filter" };
+  } catch (err) {
+    if (!filterRejected(err)) throw err;
+  }
+
+  try {
+    const result = await client.request(path, withFolderFilter({ document_folder_id: { ne: "" } }));
+    return { result, attempt: "ne-filter" };
+  } catch (err) {
+    if (!filterRejected(err)) throw err;
+  }
+
+  const result = await client.request(path, params);
+  return { result, attempt: "unfiltered" };
+}
+
+/**
+ * Enumerate an organization's document folders using API-key auth.
+ *
+ * IT Glue's public API now documents a Document Folders resource, but the
+ * rollout across tenants (2026) means a given tenant may expose it at the
+ * organization relationship path, at the top level, or not at all. Tries the
+ * relationship path first, then `/document_folders?filter[organization_id]=`
+ * if that 404s.
+ *
+ * Returns the folder listing on success, or null when the API key was
+ * rejected (401/403) or the resource is not exposed (404) — the caller should
+ * fall back to JWT auth. Any other error propagates unchanged.
+ */
+export async function listDocumentFoldersViaApiKey(
+  client: ITGlueClient,
+  organizationId: number | string,
+  params: Record<string, unknown>
+): Promise<{ data: unknown[]; meta: PaginationMeta } | null> {
+  const apiKeyBlocked = (err: unknown) => {
+    const status = apiErrorStatus(err);
+    return status === 401 || status === 403 || status === 404;
+  };
+
+  try {
+    return await client.request(
+      `/organizations/${organizationId}/relationships/document_folders`,
+      params
+    );
+  } catch (err) {
+    if (!apiKeyBlocked(err)) throw err;
+    if (apiErrorStatus(err) !== 404) return null;
+  }
+
+  // The relationship path 404'd — the tenant may expose the public resource
+  // only at the top level.
+  try {
+    return await client.request("/document_folders", {
+      ...params,
+      filter: {
+        ...((params.filter as Record<string, unknown>) ?? {}),
+        organization_id: organizationId,
+      },
+    });
+  } catch (err) {
+    if (!apiKeyBlocked(err)) throw err;
+    return null;
+  }
 }
 
 // Credential extraction from gateway headers
@@ -959,7 +1097,7 @@ export function createMcpServer(credentialOverrides?: GatewayCredentials): Serve
       },
       {
         name: "list_document_folders",
-        description: "List document folders for an organization in IT Glue, returning their names and IDs. Requires a JWT credential (configure via ITGLUE_JWT env var or X-ITGlue-JWT header, or paste one when prompted) — IT Glue's API key scope does not include folder enumeration.",
+        description: "List document folders for an organization in IT Glue, returning their names and IDs. Works with your API key on tenants where IT Glue exposes the Document Folders resource (rolling out across tenants in 2026). If the API key is rejected, a JWT is used as a fallback (configure via ITGLUE_JWT env var or X-ITGlue-JWT header, or paste one when prompted).",
         inputSchema: {
           type: "object",
           properties: {
@@ -985,7 +1123,7 @@ export function createMcpServer(credentialOverrides?: GatewayCredentials): Serve
       },
       {
         name: "create_document",
-        description: "Create a new document in IT Glue for an organization. If neither document_folder_id nor skip_folder_prompt is supplied, the user is prompted to pick a folder. When a JWT credential is configured, the prompt is a name-based picker (preferred UX); otherwise it accepts a folder URL, a sibling-document URL, or a numeric folder ID (since folder names are not in API-key scope). Pass skip_folder_prompt=true to always create at the organization root without prompting.",
+        description: "Create a new document in IT Glue for an organization. If neither document_folder_id nor skip_folder_prompt is supplied, the user is prompted to pick a folder. Folder enumeration for the name-based picker tries the API key first (works on tenants where IT Glue exposes the Document Folders resource), then a configured JWT; if neither can list folders, the prompt accepts a folder URL, a sibling-document URL, or a numeric folder ID. Pass skip_folder_prompt=true to always create at the organization root without prompting.",
         inputSchema: {
           type: "object",
           properties: {
@@ -1271,7 +1409,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const ensureJwt = async (reason: string): Promise<string | null> => {
     if (sessionJwt) return sessionJwt;
     const elicited = await elicitText(
-      `${reason} IT Glue requires a JWT for this operation (folder names and similar resources are not in API-key scope). Paste your IT Glue JWT — find it in browser DevTools → Network → any request to itg-api-*.itglue.com → Authorization: Bearer <token>. JWT expires in ~2h; you'll be re-prompted on expiry. NOTE: this token will appear in your conversation transcript.`,
+      `${reason} Your API key could not access this resource (your IT Glue tenant may not expose Document Folders to API keys yet — the rollout runs through 2026), so a JWT is needed as a fallback. Paste your IT Glue JWT — find it in browser DevTools → Network → any request to itg-api-*.itglue.com → Authorization: Bearer <token>. JWT expires in ~2h; you'll be re-prompted on expiry. NOTE: this token will appear in your conversation transcript.`,
       "jwt",
       "IT Glue JWT (e.g. eyJ0eXAiOiJKV1Qi...)"
     );
@@ -1681,14 +1819,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
 
         try {
-          const result = await client.request(
-            `/organizations/${args.organization_id}/relationships/documents`,
-            params
-          );
-          const note = rootLevelDocumentsNote({
-            folderFiltered: Boolean(args?.document_folder_id),
-            haveJwt: Boolean(sessionJwt ?? credentials.jwt),
-          });
+          let result: { data: unknown[]; meta: PaginationMeta };
+          let note: string | null;
+
+          if (args?.document_folder_id) {
+            // Explicit folder scope — single request, result is complete for
+            // that folder, no caveat needed.
+            result = await client.request(
+              `/organizations/${args.organization_id}/relationships/documents`,
+              params
+            );
+            note = null;
+          } else {
+            // No folder scope — default to the folder-INCLUSIVE listing, with
+            // layered degradation down to the legacy root-only call.
+            const attempted = await requestDocumentsWithFolderDefault(
+              client,
+              args.organization_id as number | string,
+              params
+            );
+            result = attempted.result;
+            note =
+              attempted.attempt === "unfiltered"
+                ? rootLevelDocumentsNote({
+                    folderFiltered: false,
+                    haveJwt: Boolean(sessionJwt ?? credentials.jwt),
+                  })
+                : folderedDocumentsIncludedNote();
+          }
+
           const body = JSON.stringify(result, null, 2);
           return {
             content: [
@@ -1735,16 +1894,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             isError: true,
           };
         }
-        const jwtClient = await getJwtClient("Listing IT Glue document folders.");
-        if (!jwtClient) {
-          return {
-            content: [{
-              type: "text",
-              text: "list_document_folders requires a JWT credential. Configure ITGLUE_JWT (env) or X-ITGlue-JWT (header), or paste one when prompted. See README for how to retrieve a JWT from your browser.",
-            }],
-            isError: true,
-          };
-        }
         const params: Record<string, unknown> = {};
         const filter: Record<string, unknown> = {};
         if (args?.name) filter.name = args.name;
@@ -1753,6 +1902,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           size: (args?.page_size as number) || 50,
           number: (args?.page_number as number) || 1,
         };
+
+        // API-key first: IT Glue is rolling out a public Document Folders
+        // resource, so most tenants no longer need a JWT here. Fall back to
+        // JWT auth only when the API key is rejected (401/403/404).
+        if (effectiveCredentials.apiKey) {
+          const apiKeyClient = createClient({ ...effectiveCredentials, jwt: undefined });
+          const apiKeyResult = await listDocumentFoldersViaApiKey(
+            apiKeyClient,
+            args.organization_id as number | string,
+            params
+          );
+          if (apiKeyResult) {
+            return {
+              content: [{ type: "text", text: JSON.stringify(apiKeyResult, null, 2) }],
+            };
+          }
+        }
+
+        const jwtClient = await getJwtClient("Listing IT Glue document folders.");
+        if (!jwtClient) {
+          return {
+            content: [{
+              type: "text",
+              text: "Could not list document folders. API-key access requires your IT Glue tenant's API to expose the Document Folders resource (IT Glue is rolling this out across tenants in 2026; yours does not appear to have it yet), and no JWT was available as a fallback. Configure ITGLUE_JWT (env) or X-ITGlue-JWT (header), or paste one when prompted. See README for how to retrieve a JWT from your browser.",
+            }],
+            isError: true,
+          };
+        }
         try {
           const result = await jwtClient.request(
             `/organizations/${args.organization_id}/relationships/document_folders`,
@@ -1789,34 +1966,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const skipPrompt = args.skip_folder_prompt === true;
 
         if (folderId === undefined && !skipPrompt) {
-          // Prefer the name-based picker when a JWT is already configured —
-          // it's the better UX and uses the credential the caller has
-          // already opted into. Otherwise fall back to the URL/ID parser
-          // (which works with API-key auth alone).
-          const haveJwt = Boolean(sessionJwt ?? credentials.jwt);
-          let pickerUsed = false;
+          // Enumerate folders for the name-based picker: API key first (IT
+          // Glue is rolling out a public Document Folders resource), then a
+          // JWT the caller has already configured. If neither can list
+          // folders, fall back to the URL/ID parser as the last resort.
+          const pickerParams = { page: { size: 1000, number: 1 } };
+          let folders: DocumentFolderResource[] | null = null;
 
-          if (haveJwt) {
+          if (effectiveCredentials.apiKey) {
+            const apiKeyClient = createClient({ ...effectiveCredentials, jwt: undefined });
+            const apiKeyResult = await listDocumentFoldersViaApiKey(
+              apiKeyClient,
+              args.organization_id as number | string,
+              pickerParams
+            );
+            if (apiKeyResult) {
+              folders = apiKeyResult.data as DocumentFolderResource[];
+            }
+          }
+
+          if (folders === null && Boolean(sessionJwt ?? credentials.jwt)) {
             const jwtClient = await getJwtClient("Listing folders to pick from.");
             if (jwtClient) {
               try {
                 const foldersResp = await jwtClient.request(
                   `/organizations/${args.organization_id}/relationships/document_folders`,
-                  { page: { size: 1000, number: 1 } }
+                  pickerParams
                 ) as { data?: DocumentFolderResource[] };
-                const folders = foldersResp?.data ?? [];
-                if (folders.length > 0) {
-                  pickerUsed = true;
-                  const choice = await elicitSelection(
-                    `Which folder should "${args.name}" go in?`,
-                    "folder",
-                    buildFolderPickerOptions(folders)
-                  );
-                  if (choice && choice !== "__root__") {
-                    folderId = choice;
-                  }
-                  // null choice (declined/unsupported) or "__root__" → folderId stays undefined.
-                }
+                folders = foldersResp?.data ?? [];
               } catch (err) {
                 // 401 invalidates the cached JWT and falls through to the URL
                 // parser; any other error propagates because something is
@@ -1829,6 +2006,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 }
               }
             }
+          }
+
+          let pickerUsed = false;
+          if (folders && folders.length > 0) {
+            pickerUsed = true;
+            const choice = await elicitSelection(
+              `Which folder should "${args.name}" go in?`,
+              "folder",
+              buildFolderPickerOptions(folders)
+            );
+            if (choice && choice !== "__root__") {
+              folderId = choice;
+            }
+            // null choice (declined/unsupported) or "__root__" → folderId stays undefined.
           }
 
           if (!pickerUsed) {


### PR DESCRIPTION
Closes #55. Refs wyre-technology/msp-claude-plugins#134.

## Why

Document-folder access previously hard-required a user-session JWT (short-lived ~2h, manually scraped from browser DevTools). Research established that this is no longer necessary:

- IT Glue's public API-key docs (api.itglue.com/developer) now list a **Document Folders** resource (index/show/create/update), rolling out across tenants through 2026.
- `filter[document_folder_id]=null` on `GET /organizations/:id/relationships/documents` returns **ALL** documents — foldered ones included — with an API key; the `filter[document_folder_id][ne]=` form is a community-verified alternative.
- Each returned document carries `document-folder-id`, so folder membership is reconstructable without folder enumeration.

## Design

Every folder-related path is now **API-key-first with layered graceful degradation**; the JWT becomes an optional fallback rather than a requirement.

### `search_documents`
When the caller does **not** pass `document_folder_id`, the handler now defaults to a folder-inclusive listing:

1. `filter[document_folder_id]=null` → all documents
2. on 400/422 → retry `filter[document_folder_id][ne]=`
3. on 400/422 again → legacy unfiltered (root-only) call, keeping the existing root-level-only warning note

Foldered results get a note explaining that each document's `documentFolderId` identifies its folder. Callers passing an explicit `document_folder_id` keep exact current behavior. Non-filter errors (401/404/5xx) propagate unchanged, so the existing "Documents module missing" 404 guidance is preserved.

### `list_document_folders`
Tries the API key first on `/organizations/:id/relationships/document_folders`; if that 404s, tries the top-level `/document_folders?filter[organization_id]=:id` form (the public resource may be exposed either way). Only when the API key fails with 401/403/404 does it fall back to the JWT client — current behavior, including the 401 JWT-cache-clear. The neither-credential-works error now explains that API-key access requires the tenant's API to expose Document Folders (2026 rollout) and that a JWT remains the fallback.

### `create_document` folder picker
Same API-key-first, JWT-fallback ordering for folder enumeration; the `parseFolderReference` URL/ID prompt stays as the last resort.

### Messaging sweep
Tool descriptions, error strings, README, and `manifest.json` no longer say folders "require a JWT" — the JWT is an optional fallback. All JWT plumbing (`ITGLUE_JWT` env, `X-ITGlue-JWT` gateway header, runtime paste elicitation) is fully intact.

## Tests

New unit + round-trip (real MCP server over `InMemoryTransport`, mocked fetch — no live calls) coverage:

- default `null` filter on `search_documents` (+ folder id surfaced in results)
- the 400 → `[ne]` → unfiltered degradation chain (and that 404/500 do **not** degrade)
- `list_document_folders` API-key success (relationship and top-level paths)
- API-key 403 → JWT fallback (and API-key preferred even when a JWT is configured)
- neither-credential-available actionable error
- 401 JWT-cache-clear retained
- `create_document` picker API-key-first ordering + JWT fallback

`npm run build`, `npm run lint`, and `npm test` (187 tests, 2 files) all green.

## Residual unknown

The API-key Document Folders rollout has **not** been verified against a live tenant — the rollout timing is per-tenant and our tenant's exposure is unconfirmed. The layered fallback makes this safe: if a tenant's API rejects the new filter/paths, behavior degrades to exactly what shipped before (root-only listing with warning, JWT-based folder enumeration). Live verification wanted for: (1) the `null` filter form on the documents relationship endpoint, (2) which path exposes Document Folders (relationship vs top-level), (3) the exact rejection status codes on non-enrolled tenants.