### PR TITLE
fix(documents): strip document bodies from search_documents results (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,19 @@
 
 ### Fixed
 
+- **`search_documents` no longer inlines document bodies, which made foldered
+  organizations hang.** ([#55](https://github.com/wyre-technology/itglue-mcp/issues/55))
+  IT Glue's documents LIST endpoint embeds each document's full sectioned body
+  under `content` (~90% of the payload). After the folder-inclusive default
+  landed, an org-wide `search_documents` returned *every* document — each with
+  its full body — so a heavily-foldered org (e.g. 1,100+ documents) produced a
+  multi-megabyte response that exceeded the MCP client's limit and appeared to
+  hang with no error (subfolders enumerated fine, but viewing the documents
+  inside them failed). `search_documents` now strips the body from every result
+  (an 84% size reduction on a representative page) and returns metadata only —
+  `name`, `documentFolderId`, `resourceUrl`, timestamps, etc. Full bodies remain
+  available through `get_document` and `list_document_sections`. Applies to both
+  the folder-inclusive default and explicit `document_folder_id` searches.
 - **GitHub Packages auth:** `.npmrc` now reads a `read:packages` token from
   `NODE_AUTH_TOKEN`, and the README install instructions document the required
   `export NODE_AUTH_TOKEN=$(gh auth token)` step so consumers can install the

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2466,6 +2466,47 @@ describe("Document folder access (API-key-first, round-trip)", () => {
     });
   });
 
+  // search_documents strips bodies to stay small, so the full document body MUST
+  // remain reachable through get_document — that is the read path the list tool
+  // points callers to. This pins it so a future change can't silently strip the
+  // read path too (issue #55).
+  describe("get_document (full-body read path)", () => {
+    it("returns the complete document body, unstripped", async () => {
+      const client = await connectClient({ apiKey: "test-api-key" });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: "20022034",
+            type: "documents",
+            attributes: {
+              name: "00-1 READ ME",
+              "document-folder-id": 6262993,
+              content: [
+                { id: 9, resource: { content: "<p>FULL_BODY_MARKER</p>" } },
+              ],
+            },
+          },
+          meta: {},
+        })
+      );
+
+      const result = await client.callTool({
+        name: "get_document",
+        arguments: { organization_id: 8250506, id: 20022034 },
+      });
+
+      const text = firstText(result);
+      // The body the list tool omits is present here in full.
+      expect(text).toContain("FULL_BODY_MARKER");
+      expect(text).toContain('"content"');
+      expect(text).toContain("00-1 READ ME");
+      // Fetched from the single-document relationship endpoint.
+      expect(decodedUrl(0)).toContain(
+        "/organizations/8250506/relationships/documents/20022034"
+      );
+    });
+  });
+
   describe("list_document_folders", () => {
     it("succeeds with the API key alone (no JWT involved)", async () => {
       const client = await connectClient({ apiKey: "test-api-key" });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -29,6 +29,7 @@ import {
   parseFolderReference,
   requestDocumentsWithFolderDefault,
   rootLevelDocumentsNote,
+  stripDocumentBodies,
 } from "../index.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -781,6 +782,29 @@ describe("Tool Handler Integration", () => {
       const note = folderedDocumentsIncludedNote();
       expect(note).toContain("includes documents inside folders");
       expect(note).toContain("documentFolderId");
+    });
+  });
+
+  // Issue #55 follow-up: IT Glue's documents LIST endpoint inlines every
+  // document's full sectioned body under `content`, dominating the payload and
+  // making foldered orgs exceed the MCP client's response limit. search_documents
+  // must return metadata only.
+  describe("stripDocumentBodies", () => {
+    it("removes the content array while preserving all other document fields", () => {
+      const stripped = stripDocumentBodies([
+        {
+          id: "1",
+          name: "Doc",
+          documentFolderId: 42,
+          content: [{ id: 9, resource: { content: "<p>body</p>" } }],
+        },
+      ]);
+      expect(stripped).toEqual([{ id: "1", name: "Doc", documentFolderId: 42 }]);
+    });
+
+    it("leaves documents without a content field untouched", () => {
+      const docs = [{ id: "2", name: "Root Doc", documentFolderId: null }];
+      expect(stripDocumentBodies(docs)).toEqual(docs);
     });
   });
 
@@ -2308,12 +2332,58 @@ describe("Document folder access (API-key-first, round-trip)", () => {
       expect(text).toContain('"documentFolderId": 42');
     });
 
-    it("keeps exact current behavior for an explicit document_folder_id", async () => {
+    it("omits heavy document body content from list results (metadata only)", async () => {
+      const client = await connectClient({ apiKey: "test-api-key" });
+      // IT Glue's documents list endpoint embeds each document's full sectioned
+      // body in a `content` array. Passing that straight through makes list
+      // responses enormous (a single foldered org can exceed the MCP client's
+      // limit and hang with no error — issue #55). search_documents is a
+      // LIST/SEARCH tool: it must return lightweight metadata, not full bodies.
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            {
+              id: "1",
+              type: "documents",
+              attributes: {
+                name: "Change Management SOP",
+                "document-folder-id": 42,
+                content: [
+                  { id: 9, resource: { content: "<p>HEAVY_BODY_MARKER</p>" } },
+                ],
+              },
+            },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "search_documents",
+        arguments: { organization_id: 123 },
+      });
+
+      const text = firstText(result);
+      // Metadata the model needs to list/locate documents is preserved.
+      expect(text).toContain("Change Management SOP");
+      expect(text).toContain('"documentFolderId": 42');
+      // The full body is NOT inlined — it belongs to get_document.
+      expect(text).not.toContain("HEAVY_BODY_MARKER");
+      expect(text).not.toContain('"content"');
+    });
+
+    it("issues a single kebab-case filter request for an explicit document_folder_id", async () => {
       const client = await connectClient({ apiKey: "test-api-key" });
       mockFetch.mockResolvedValueOnce(
         createMockResponse(
           createJsonApiResponse([
-            { id: "1", type: "documents", attributes: { name: "Doc" } },
+            {
+              id: "1",
+              type: "documents",
+              attributes: {
+                name: "Doc",
+                content: [{ id: 9, resource: { content: "HEAVY_BODY_MARKER" } }],
+              },
+            },
           ])
         )
       );
@@ -2326,7 +2396,12 @@ describe("Document folder access (API-key-first, round-trip)", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(decodedUrl(0)).toContain("filter[document-folder-id]=42");
       expect(decodedUrl(0)).not.toContain("filter[document_folder_id]=null");
-      expect(firstText(result)).not.toContain("NOTE:");
+      // No folder-inclusive caveat for an explicit scope, but bodies are still
+      // stripped (the per-folder listing inlines full bodies too — issue #55).
+      const text = firstText(result);
+      expect(text).not.toContain("includes documents inside folders");
+      expect(text).toContain("document bodies are omitted");
+      expect(text).not.toContain("HEAVY_BODY_MARKER");
     });
 
     it("degrades 400 → [ne] filter and still reports foldered docs included", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,13 @@ export {
   ITGlueClient,
   buildFolderPickerOptions,
   createDocumentWithContent,
+  documentBodyOmittedNote,
   folderedDocumentsIncludedNote,
   listDocumentFoldersViaApiKey,
   parseFolderReference,
   requestDocumentsWithFolderDefault,
   rootLevelDocumentsNote,
+  stripDocumentBodies,
 } from "./mcp-server.js";
 export type {
   DocumentSearchAttempt,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -518,6 +518,40 @@ export function folderedDocumentsIncludedNote(): string {
   );
 }
 
+/**
+ * Strip each document's full body from a `search_documents` listing.
+ *
+ * IT Glue's documents list endpoint embeds every document's full sectioned body
+ * in a `content` array. That body dominates the payload — on a heavily-foldered
+ * org it is ~90% of the bytes — so passing it through makes the list response so
+ * large it can exceed the MCP client's response limit and hang with no error
+ * (issue #55: folder enumeration works, but viewing the documents inside chokes).
+ * search_documents is a LIST/SEARCH tool, so it returns metadata only; full-body
+ * retrieval stays with get_document / list_document_sections.
+ *
+ * Coupled to IT Glue's current field name: the body arrives as a top-level
+ * `content` key (deserializeResource flattens `attributes` and camelCases keys).
+ * If IT Glue renames the body field or adds another heavy one, revisit this.
+ */
+export function stripDocumentBodies(docs: unknown[]): unknown[] {
+  return docs.map((doc) => {
+    if (doc && typeof doc === "object" && "content" in doc) {
+      const { content: _body, ...rest } = doc as Record<string, unknown>;
+      return rest;
+    }
+    return doc;
+  });
+}
+
+/** Advisory that document bodies are omitted from `search_documents` results. */
+export function documentBodyOmittedNote(): string {
+  return (
+    "NOTE: document bodies are omitted from these results to keep the listing small — each " +
+    "item is metadata only. Call get_document (or list_document_sections) to read a specific " +
+    "document's content."
+  );
+}
+
 /** Which filter form ultimately produced a `search_documents` listing. */
 export type DocumentSearchAttempt = "null-filter" | "ne-filter" | "unfiltered";
 
@@ -1045,7 +1079,7 @@ export function createMcpServer(credentialOverrides?: GatewayCredentials): Serve
       // Documents
       {
         name: "search_documents",
-        description: "Search for documents in IT Glue (scoped to an organization)",
+        description: "Search for documents in IT Glue (scoped to an organization). Returns document metadata only (name, folder, URL, timestamps) — not the document body. Use get_document or list_document_sections to read a specific document's content.",
         inputSchema: {
           type: "object",
           properties: {
@@ -1848,14 +1882,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 : folderedDocumentsIncludedNote();
           }
 
-          const body = JSON.stringify(result, null, 2);
+          // Drop each document's full body — search_documents is a list tool,
+          // and IT Glue's list endpoint inlines the entire sectioned body per
+          // document, which can balloon the response past the client's limit
+          // (issue #55). Bodies stay available via get_document.
+          const trimmed = { ...result, data: stripDocumentBodies(result.data) };
+          const text = [documentBodyOmittedNote(), note, JSON.stringify(trimmed, null, 2)]
+            .filter(Boolean)
+            .join("\n\n");
           return {
-            content: [
-              {
-                type: "text",
-                text: note ? `${note}\n\n${body}` : body,
-              },
-            ],
+            content: [{ type: "text", text }],
           };
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Fixes the follow-up reported on [#55](https://github.com/wyre-technology/itglue-mcp/issues/55#issuecomment-4935736246): after v1.14.0, `list_document_folders` enumerates subfolders fine, but **viewing the documents inside them silently hangs** at `search_documents` with no error.

## Root cause

IT Glue's documents **list** endpoint (`/organizations/:id/relationships/documents`) inlines every document's full sectioned HTML body under a `content` array. Measured against a live tenant, that body is **~90% of the payload** — a 100-document page was **462 KB**, which exceeded even our own harness's token limit.

v1.14.0 (#71) turned this latent bloat into a hard failure: by flipping the default from *root-level-only* to *folder-inclusive*, `search_documents` began returning **every** document in an org, each with its full body. For a heavily-foldered org (the reporter has 1,100+ docs), the response becomes multiple megabytes — past the MCP client's limit — so the call hangs with no error. That's exactly why folder *enumeration* works (that endpoint is lean) but viewing folder *contents* chokes.

## Fix

`search_documents` is a list/search tool, so it now strips each document's `content` body and returns **metadata only** (`name`, `documentFolderId`, `resourceUrl`, timestamps). Full bodies remain available via `get_document` and `list_document_sections`. Applied to both the folder-inclusive default and explicit `document_folder_id` paths, with an advisory note telling the model where to read bodies.

## Verification

- **End-to-end against the real captured tenant payload:** 462 KB → 76 KB (**84% reduction**), no `content` leaks, all metadata preserved. At the default 50-doc page size a page drops from ~230 KB to ~38 KB.
- 190 unit/integration tests pass (added `stripDocumentBodies` unit tests + a round-trip test asserting bodies are stripped through the real MCP handler); TDD red→green.
- `tsc` build clean, `eslint` clean.

## Review

Passed an adversarial code review (no Critical/Important issues) and a 4-angle `/simplify` pass (reuse / simplification / efficiency / altitude). Altitude review confirmed the handler is the correct layer — moving the strip into the shared `request()`/`deserializeResource` would break `get_document`, and the other five `search_*` tools were verified not to have the same bloat (per-tool suppression matches the existing `show_password` pattern).

### Noted follow-ups (out of scope for this fix)
- Request a sparse JSON:API fieldset (`fields[documents]=…`) so IT Glue never sends `content` over the wire — saves network + parse cost, not just the client-forwarded payload. (Depends on IT Glue honoring sparse fieldsets; needs live verification.)
- A shared response-size guard / page-size clamp protecting **all** list tools from silently exceeding the MCP client limit.

Closes #55.