### PR TITLE
fix: ignore unresolved config placeholders in credentials (#73)

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,9 +21,12 @@ vi.stubGlobal("fetch", mockFetch);
 // server during tests.
 import {
   buildFolderPickerOptions,
+  cleanCredential,
+  createClient,
   createDocumentWithContent,
   createMcpServer,
   folderedDocumentsIncludedNote,
+  getCredentialsFromEnv,
   ITGlueClient,
   listDocumentFoldersViaApiKey,
   parseFolderReference,
@@ -425,6 +428,71 @@ describe("Credential Validation", () => {
 
     const region = process.env.ITGLUE_REGION || "us";
     expect(region).toBe("eu");
+  });
+});
+
+// Regression tests for issue #73: on v1.14.1 the desktop (MCPB) install 401'd
+// every request. The manifest maps ITGLUE_JWT/ITGLUE_REGION to ${user_config.*};
+// when the optional itglue_jwt field is left blank the host injects the literal,
+// unresolved string "${user_config.itglue_jwt}". The server read that as a JWT
+// and — because a JWT overrides the API key — sent
+// `Authorization: Bearer ${user_config.itglue_jwt}` on every call, so a valid
+// API key never got a chance. Credentials must be sanitised at ingress.
+describe("issue #73: unresolved MCPB config placeholders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("cleanCredential drops empty, whitespace, and ${...} placeholder values", () => {
+    expect(cleanCredential(undefined)).toBeUndefined();
+    expect(cleanCredential("")).toBeUndefined();
+    expect(cleanCredential("   ")).toBeUndefined();
+    expect(cleanCredential("${user_config.itglue_jwt}")).toBeUndefined();
+    expect(cleanCredential("  ${user_config.itglue_jwt}  ")).toBeUndefined();
+  });
+
+  it("cleanCredential preserves and trims real credentials", () => {
+    expect(cleanCredential("eyJ0eXAiOiJKV1Qi.real.jwt")).toBe("eyJ0eXAiOiJKV1Qi.real.jwt");
+    expect(cleanCredential("  real-api-key  ")).toBe("real-api-key");
+  });
+
+  it("getCredentialsFromEnv ignores a placeholder ITGLUE_JWT but keeps the API key", () => {
+    process.env.ITGLUE_API_KEY = "real-api-key";
+    process.env.ITGLUE_JWT = "${user_config.itglue_jwt}";
+
+    const creds = getCredentialsFromEnv();
+
+    expect(creds.apiKey).toBe("real-api-key");
+    expect(creds.jwt).toBeUndefined();
+  });
+
+  it("falls back to region 'us' when ITGLUE_REGION is an unresolved placeholder", () => {
+    process.env.ITGLUE_API_KEY = "real-api-key";
+    process.env.ITGLUE_REGION = "${user_config.itglue_region}";
+
+    expect(getCredentialsFromEnv().region).toBe("us");
+  });
+
+  it("authenticates with the API key, not a bogus Bearer placeholder (the 401 repro)", async () => {
+    process.env.ITGLUE_API_KEY = "real-api-key";
+    process.env.ITGLUE_JWT = "${user_config.itglue_jwt}";
+
+    let captured: Record<string, string> = {};
+    mockFetch.mockImplementation((_url: string, options: RequestInit) => {
+      captured = options.headers as Record<string, string>;
+      return createMockResponse(createJsonApiResponse([]));
+    });
+
+    const client = createClient(getCredentialsFromEnv());
+    await client.request("/organizations", {});
+
+    expect(captured["x-api-key"]).toBe("real-api-key");
+    expect(captured["Authorization"]).toBeUndefined();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,9 @@ import {
 export {
   createMcpServer,
   createClient,
+  cleanCredential,
   getCredentialsFromEnv,
+  sanitizeCredentials,
   ITGlueClient,
   buildFolderPickerOptions,
   createDocumentWithContent,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -664,13 +664,68 @@ export interface GatewayCredentials {
   baseUrl?: string;
 }
 
-export function getCredentialsFromEnv(): GatewayCredentials {
+// An unresolved MCPB/DXT manifest placeholder, e.g. "${user_config.itglue_jwt}".
+// Desktop hosts inject the config template verbatim when its optional user_config
+// field is left blank, so the literal string arrives in the env var / header.
+const CONFIG_PLACEHOLDER = /^\$\{.*\}$/;
+
+/**
+ * Normalise a single credential read from an env var or gateway header.
+ *
+ * Returns `undefined` for values that are effectively absent, so the auth layer
+ * treats them as "no credential" rather than a real secret:
+ *   - undefined / empty / whitespace-only
+ *   - an unresolved manifest placeholder like `${user_config.itglue_jwt}`
+ *
+ * Root cause of issue #73: a blank optional JWT field left the literal
+ * `${user_config.itglue_jwt}` in ITGLUE_JWT. Because a JWT overrides the API key
+ * (see ITGlueClient.authHeaders), every request went out as
+ * `Authorization: Bearer ${user_config.itglue_jwt}` and 401'd — even with a valid
+ * API key configured. Stripping the placeholder here lets the API key take over.
+ */
+export function cleanCredential(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || CONFIG_PLACEHOLDER.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+// Warn at most once per field so a stray placeholder surfaces in the server log
+// (a clear diagnostic for the operator) without spamming it on every tool call.
+const warnedPlaceholderFields = new Set<string>();
+function warnPlaceholderOnce(field: string): void {
+  if (warnedPlaceholderFields.has(field)) return;
+  warnedPlaceholderFields.add(field);
+  console.error(
+    `[itglue-mcp] Ignoring ${field}: value is an unresolved config placeholder ` +
+      `(e.g. "\${user_config...}"), not a real credential. This usually means an ` +
+      `optional field was left blank in your MCP client config. (issue #73)`
+  );
+}
+
+/**
+ * Sanitise every field of a credential set at ingress, dropping empty and
+ * unresolved-placeholder values. Applied to both credential sources (env and
+ * gateway headers) so a placeholder never reaches the auth layer as a secret.
+ */
+export function sanitizeCredentials(creds: GatewayCredentials): GatewayCredentials {
+  if (creds.jwt && CONFIG_PLACEHOLDER.test(creds.jwt.trim())) {
+    warnPlaceholderOnce("ITGLUE_JWT / X-ITGlue-JWT");
+  }
   return {
+    apiKey: cleanCredential(creds.apiKey),
+    jwt: cleanCredential(creds.jwt),
+    region: (cleanCredential(creds.region) ?? "us") as ITGlueRegion,
+    baseUrl: cleanCredential(creds.baseUrl),
+  };
+}
+
+export function getCredentialsFromEnv(): GatewayCredentials {
+  return sanitizeCredentials({
     apiKey: process.env.ITGLUE_API_KEY || process.env.X_API_KEY,
     jwt: process.env.ITGLUE_JWT,
     region: (process.env.ITGLUE_REGION || "us") as ITGlueRegion,
     baseUrl: process.env.ITGLUE_BASE_URL,
-  };
+  });
 }
 
 export function createClient(credentials: GatewayCredentials): ITGlueClient {
@@ -1407,7 +1462,9 @@ let sessionJwt: string | undefined;
 // Handle tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
-  const credentials = credentialOverrides ?? getCredentialsFromEnv();
+  const credentials = credentialOverrides
+    ? sanitizeCredentials(credentialOverrides)
+    : getCredentialsFromEnv();
 
   // Seed the session JWT slot from credentials on first call (avoids
   // recomputing every tool invocation).


### PR DESCRIPTION
Fixes #73

## The bug

On the **v1.14.1** desktop (MCPB) install, connecting to IT Glue **401'd on every request** — even after re-entering the key, reinstalling, or hardcoding the API key in the manifest.

## Root cause

`manifest.json` maps `ITGLUE_JWT` (and `ITGLUE_REGION`) to `${user_config.*}`. `itglue_jwt` is an **optional** field, and when it's left blank the desktop host injects the **literal, unresolved string** `${user_config.itglue_jwt}` into the env var.

The server read that as a real JWT. Because a JWT **overrides** the API key (`ITGlueClient.authHeaders`), every request went out as:

```
Authorization: Bearer ${user_config.itglue_jwt}
```

…so a perfectly valid API key never got used → 401 on everything.

> Note: `#134` (which *declares* the `itglue_jwt` field) is already in v1.14.1, and the reporter still hit this — declaring the field isn't enough because the host still injects the placeholder for a blank optional field. The robust fix has to be server-side.

## The fix

Sanitize credentials **at ingress** so a placeholder never reaches the auth layer as if it were a secret:

- `cleanCredential(value)` — returns `undefined` for empty, whitespace-only, and unresolved `${...}` placeholder values.
- `sanitizeCredentials(creds)` — applies it to `apiKey` / `jwt` / `baseUrl`; `region` falls back to `"us"` (it has the same placeholder trap).
- Wired into **both** credential sources: `getCredentialsFromEnv()` (stdio/desktop — the reported path) and `createMcpServer()` overrides (the HTTP and Cloudflare Worker gateways).
- A **one-time stderr warning** flags a stripped JWT placeholder so operators get a clear diagnostic instead of a silent 401.

The manifest is intentionally left as-is: the `ITGLUE_JWT` mapping is legitimate when a user *does* supply a JWT, and the server now handles the empty case correctly.

## Tests

Added a `issue #73` regression block that reproduces the exact failure (a placeholder `ITGLUE_JWT` alongside a real API key must send `x-api-key`, not `Authorization: Bearer ${...}`), plus unit coverage for `cleanCredential` and the region fallback.

- `npm test` — **196 passed**
- `npm run lint` / `typecheck` / `build` — clean