### PR TITLE
ci: adopt codeql-action v4 (node24) via reusable-workflow pin bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,11 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
       packages: write
       id-token: write
       security-events: write
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@a925b43adb22aa8885b8243e1056e6a42cdce4d1
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@d28a612a00a1bd0c36aff09e686ce2d1e10ef552
     with:
       server-name: itglue-mcp
       image-name: ghcr.io/wyre-technology/itglue-mcp


### PR DESCRIPTION
Fleet propagation of wyre-technology/.github#39 (codeql-action `upload-sarif` v3.35.3 → v4.37.3, node20 → **node24**).

- Bumps `mcp-server-release.yml` reusable pin `a925b43` → `d28a612`.
- Adds `pull-requests: write` to the release job — the `d28a612` reusable release job now declares it (for @semantic-release/github's success step); a reusable can only reduce caller scope, so the caller must grant it (documented CALLER PROPAGATION requirement).

Verified end-to-end on autotask-mcp (#210, released cleanly at this pin). node20 codeql is a deprecation warning until 2026-09-16, then a hard failure — this clears it fleet-wide.