### PR TITLE
fix(security): eliminate cross-tenant server-ref misroute in elicitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 ## [Unreleased]
 
+### Security
+
+- **Cross-tenant elicitation/confirmation misroute (gateway mode).** The
+  "server reference" used by elicitation helpers (`src/utils/elicitation.ts`
+  — `elicitSelection` / `elicitText` / `elicitConfirmation`) was stored in a
+  module-level `let _server: Server | null` singleton in
+  `src/utils/server-ref.ts`, set synchronously per request via
+  `setServerRef(server)` (called from `createMcpServer()` in
+  `src/mcp-server.ts`) and read back later via `getServerRef()` — including
+  after `await` gaps inside async tool handlers (e.g. after awaiting an IT
+  Glue API call, before sending an elicitation/confirmation prompt back
+  through "the" server).
+  - **Impact:** in gateway (multi-tenant HTTP) mode — `AUTH_MODE=gateway` —
+    a fresh `Server` instance is created per inbound request, so two
+    concurrent tenant requests could race through the shared global: tenant
+    A's request sets the ref and starts awaiting async work; before A
+    resumes, tenant B's request runs and overwrites the module-level ref
+    with B's server/transport; when A's awaited work resolves and it reads
+    the ref back to call `elicitInput`, it gets B's server — so A's
+    elicitation/confirmation prompt is sent down B's connection instead of
+    A's (or vice versa, depending on timing). Same shared-mutable-state
+    -across-await-gaps bug class as the credential-leak fixes in
+    liongard-mcp#58, ninjaone-mcp#71, and the reference fix in
+    halopsa-mcp#65, but in the server/transport routing subsystem for
+    elicitation, not credential/token caching.
+  - **Fix:** replaced the module-level singleton with an `AsyncLocalStorage<Server>`
+    context (`runWithServerRef` for per-request transports — Node HTTP,
+    Workers — and `bindServerRef` for the single-session stdio transport).
+    `getServerRef()` now reads from the ALS context instead of a shared
+    variable, so it is correctly scoped to the request that created it and
+    survives arbitrary `await` gaps without observing a concurrent
+    request's server. There is no module-level mutable server/transport
+    state left in `src/utils/server-ref.ts`. Call sites updated:
+    `src/mcp-server.ts` (`createMcpServer` no longer calls `setServerRef`),
+    `src/index.ts` (Node HTTP handler wraps the connect/then/catch chain in
+    `runWithServerRef`; stdio calls `bindServerRef` once at startup),
+    `src/worker.ts` (Cloudflare Workers `handleMcp` wraps the
+    connect/handleRequest chain in `runWithServerRef`). Unlike
+    halopsa-mcp, this repo's gateway credentials are already passed as a
+    per-call function parameter (`createMcpServer(credentialOverrides)`)
+    rather than a second AsyncLocalStorage context, so no separate
+    credential-isolation fix was needed here — only the server reference
+    was affected.
+  - **Regression test:** `src/__tests__/server-ref.test.ts` forces a
+    deterministic interleave (a manually-resolved "gate" promise, not a
+    timing stagger) where tenant A binds its server and suspends on an
+    await gap, tenant B's entire request runs to completion in the
+    meantime, and only then does tenant A resume and elicit. The test
+    asserts by value which tenant's mock `elicitInput` actually received
+    each message. Verified to fail with the exact predicted symptom
+    (`expected 'tenant-B' to be 'tenant-A'`) against a reinstated
+    module-singleton implementation, and to pass against the ALS-based fix.
+
 ### Changed
 
 - **API-key-first document folder access (JWT now an optional fallback):**

--- a/src/__tests__/server-ref.test.ts
+++ b/src/__tests__/server-ref.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression test: cross-tenant "server reference" misrouting.
+ *
+ * Historically the server reference used by elicitation helpers
+ * (`utils/elicitation.ts`) was stored in a module-level `let _server`
+ * singleton in `utils/server-ref.ts` (`setServerRef` / `getServerRef`),
+ * set synchronously per request and read back later — including after
+ * `await` gaps inside async tool handlers (e.g. after awaiting an IT Glue
+ * API call, before sending an elicitation/confirmation prompt back through
+ * "the" server).
+ *
+ * In gateway (multi-tenant HTTP) mode a fresh `Server` is created per
+ * request, so two concurrent requests raced through that shared global:
+ * tenant A's request sets the ref and starts awaiting async work; before A
+ * resumes, tenant B's request runs to completion and overwrites the
+ * module-level ref with B's server/transport; when A's awaited work
+ * resolves and it reads the ref back to call `elicitInput`, it gets B's
+ * server — so A's confirmation prompt is sent down B's connection instead
+ * of A's (or vice versa, depending on timing).
+ *
+ * The fix replaces the module-level singleton with an AsyncLocalStorage
+ * context (`runWithServerRef` / `bindServerRef` / `getServerRef`), scoped
+ * per request and correctly restored across await gaps.
+ *
+ * This test forces the exact interleave deterministically — via a
+ * manually-resolved "gate" promise, not a timing-based stagger — and
+ * asserts, BY VALUE, which tenant's mock server actually received the
+ * elicitation call. (Verified by temporarily reinstating a module-singleton
+ * implementation behind the same function names: this test fails with
+ * tenant A's prompt observed on tenant B's mock `elicitInput`, and passes
+ * again once the ALS-based fix is restored — see the PR description.)
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { runWithServerRef, bindServerRef, getServerRef } from "../utils/server-ref.js";
+import { elicitConfirmation } from "../utils/elicitation.js";
+
+/** A deferred promise the test can resolve on demand, for a deterministic forced interleave. */
+function createDeferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+type FakeServer = Server & { tenantId: string; elicitInput: ReturnType<typeof vi.fn> };
+
+/** Minimal fake MCP Server whose elicitInput is a per-instance spy (per-tenant mock). */
+function createFakeServer(tenantId: string): FakeServer {
+  const elicitInput = vi.fn().mockImplementation(async () => ({
+    action: "accept" as const,
+    content: { confirm: true },
+  }));
+  return { tenantId, elicitInput } as unknown as FakeServer;
+}
+
+describe("server-ref cross-tenant isolation", () => {
+  it("getServerRef returns null outside of any bound context", () => {
+    expect(getServerRef()).toBeNull();
+  });
+
+  it("getServerRef resolves the server bound by runWithServerRef within its scope", async () => {
+    const server = createFakeServer("tenant-X");
+    await runWithServerRef(server, async () => {
+      expect(getServerRef()).toBe(server);
+    });
+  });
+
+  it(
+    "routes each tenant's elicitation through its OWN server, even when a " +
+      "second tenant's request runs to completion while the first is still " +
+      "in flight (forced deterministic interleave, not a timing stagger)",
+    async () => {
+      const serverA = createFakeServer("tenant-A");
+      const serverB = createFakeServer("tenant-B");
+      const gate = createDeferred<void>();
+
+      // Tenant A: binds its server, then suspends on an await gap
+      // (simulating an in-flight IT Glue API call inside a tool handler)
+      // BEFORE sending its elicitation/confirmation prompt.
+      const tenantA = runWithServerRef(serverA, async () => {
+        await gate.promise; // the exact await gap the original bug lost the ref across
+        expect((getServerRef() as FakeServer | null)?.tenantId).toBe("tenant-A"); // must still be A's server after resuming
+        return elicitConfirmation("Confirm tenant A's sensitive action?");
+      });
+
+      // Force the interleave: tenant B's ENTIRE request — bind, elicit,
+      // resolve — runs to completion while tenant A is still suspended
+      // above, exactly like a second concurrent HTTP request racing in.
+      const tenantB = runWithServerRef(serverB, async () => {
+        return elicitConfirmation("Confirm tenant B's sensitive action?");
+      });
+      await tenantB;
+
+      // Only now let tenant A resume.
+      gate.resolve();
+      const resultA = await tenantA;
+      expect(resultA).toBe(true);
+
+      // --- Per-tenant VALUE assertions -----------------------------------
+      // Each tenant's prompt must have gone out through THAT tenant's mock
+      // server specifically, not the other tenant's.
+      expect(serverA.elicitInput).toHaveBeenCalledTimes(1);
+      expect(serverA.elicitInput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Confirm tenant A's sensitive action?",
+        })
+      );
+
+      expect(serverB.elicitInput).toHaveBeenCalledTimes(1);
+      expect(serverB.elicitInput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Confirm tenant B's sensitive action?",
+        })
+      );
+
+      // Explicit negative checks: A's message must never have reached B's
+      // transport, and B's must never have reached A's.
+      for (const call of serverA.elicitInput.mock.calls) {
+        expect(call[0].message).not.toBe(
+          "Confirm tenant B's sensitive action?"
+        );
+      }
+      for (const call of serverB.elicitInput.mock.calls) {
+        expect(call[0].message).not.toBe(
+          "Confirm tenant A's sensitive action?"
+        );
+      }
+    }
+  );
+
+  it("bindServerRef binds for the remainder of the current async execution (stdio single-session mode)", async () => {
+    const server = createFakeServer("tenant-X");
+    bindServerRef(server);
+    // Simulate work continuing across an await gap in the same "session".
+    await Promise.resolve();
+    expect(getServerRef()).toBe(server);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   type GatewayCredentials,
   type ITGlueRegion,
 } from "./mcp-server.js";
+import { runWithServerRef, bindServerRef } from "./utils/server-ref.js";
 
 // Re-export the shared factory + IT Glue client/helpers so existing consumers
 // (and tests) that import from the package entry keep working after the
@@ -51,6 +52,10 @@ export type {
  */
 async function startStdioTransport(): Promise<void> {
   const server = createMcpServer();
+  // stdio is single-session (one process = one caller), so there is no
+  // concurrent tenant to isolate from — bind once for the process
+  // lifetime rather than per-request. See utils/server-ref.ts.
+  bindServerRef(server);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("IT Glue MCP server running on stdio");
@@ -139,18 +144,26 @@ async function startHttpTransport(): Promise<void> {
         server.close();
       });
 
-      server.connect(transport as unknown as Transport).then(() => {
-        transport.handleRequest(req, res);
-      }).catch((err) => {
-        console.error("MCP transport error:", err);
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({
-            jsonrpc: "2.0",
-            error: { code: -32603, message: "Internal error" },
-            id: null,
-          }));
-        }
+      // Bind this request's server into the per-request async context
+      // (not a module-level global) so elicitation helpers resolve *this*
+      // server/transport even after await gaps, and never a concurrent
+      // request's — see utils/server-ref.ts. The whole connect/then/catch
+      // chain must stay inside this callback so the bound context survives
+      // every await gap between here and any later getServerRef() call.
+      runWithServerRef(server, () => {
+        server.connect(transport as unknown as Transport).then(() => {
+          transport.handleRequest(req, res);
+        }).catch((err) => {
+          console.error("MCP transport error:", err);
+          if (!res.headersSent) {
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({
+              jsonrpc: "2.0",
+              error: { code: -32603, message: "Internal error" },
+              id: null,
+            }));
+          }
+        });
       });
 
       return;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -15,7 +15,6 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { setServerRef } from "./utils/server-ref.js";
 import { elicitSelection, elicitText } from "./utils/elicitation.js";
 import { registerPromptHandlers } from "./prompts.js";
 import { registerResourceHandlers } from "./resources.js";
@@ -745,6 +744,12 @@ export function createClient(credentials: GatewayCredentials): ITGlueClient {
 /**
  * Create a fresh MCP Server with all tool handlers registered.
  * Called per-request in HTTP (stateless) mode so each initialize gets a clean server.
+ *
+ * The returned server is NOT registered as "the" server anywhere here —
+ * callers are responsible for binding it into the per-request `server-ref`
+ * AsyncLocalStorage context (via `runWithServerRef` / `bindServerRef`) so
+ * elicitation helpers resolve the right server even after await gaps. See
+ * `utils/server-ref.ts` for why this matters.
  */
 export function createMcpServer(credentialOverrides?: GatewayCredentials): Server {
   const server = new Server(
@@ -760,7 +765,6 @@ export function createMcpServer(credentialOverrides?: GatewayCredentials): Serve
       },
     }
   );
-  setServerRef(server);
 
   // Register prompt handlers
   registerPromptHandlers(server);

--- a/src/utils/server-ref.ts
+++ b/src/utils/server-ref.ts
@@ -1,15 +1,72 @@
 /**
- * Shared MCP Server reference for elicitation support.
- * Avoids circular imports by decoupling server instance from domain handlers.
+ * Per-request MCP Server reference for elicitation support.
+ *
+ * Avoids circular imports by decoupling the server instance from domain
+ * handlers, without leaking that reference across concurrent requests.
+ *
+ * SECURITY (cross-tenant misroute): this used to be a module-level
+ * `let _server` singleton, set synchronously per request via `setServerRef`
+ * and read back later via `getServerRef` — including after `await` gaps
+ * inside async tool handlers (e.g. after awaiting an IT Glue API call,
+ * before sending an elicitation/confirmation prompt back through "the"
+ * server).
+ *
+ * In gateway (multi-tenant HTTP) mode a fresh `Server` is created per
+ * request, so two concurrent requests race through that shared global:
+ * tenant A's request sets the ref and starts awaiting async work; before A
+ * resumes, tenant B's request runs and overwrites the module-level ref with
+ * B's server/transport; when A's awaited work resolves and it reads the ref
+ * back to call `elicitInput`, it gets B's server and A's confirmation prompt
+ * is sent down B's connection instead of A's.
+ *
+ * Fixed by binding the server reference to an AsyncLocalStorage context
+ * instead of a shared mutable variable. ALS scopes the value to the async
+ * call graph it was entered from, and correctly restores it after arbitrary
+ * `await` gaps, so concurrent requests can never observe each other's
+ * server.
+ *
+ * There is intentionally no module-level mutable server/transport state in
+ * this file.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 
-let _server: Server | null = null;
+/**
+ * Per-request server store.
+ */
+const serverRefStore = new AsyncLocalStorage<Server>();
 
-export function setServerRef(server: Server): void {
-  _server = server;
+/**
+ * Run a callback with `server` bound to the async context for the duration
+ * of that callback — including anything it `await`s or schedules (promise
+ * chains, timers, etc). Use this for transports that create a fresh
+ * `Server` per inbound request (HTTP, Workers), one call per request, so
+ * concurrent requests never observe each other's server reference.
+ */
+export function runWithServerRef<T>(server: Server, fn: () => T): T {
+  return serverRefStore.run(server, fn);
 }
 
+/**
+ * Bind `server` for the remainder of the current synchronous execution and
+ * all following async work, without requiring a wrapping callback.
+ *
+ * Only safe for single-session transports (stdio) where exactly one
+ * `Server` instance lives for the whole process and there are no
+ * concurrent tenants to isolate from each other. Do NOT use this for
+ * per-request transports (HTTP / Workers) — use `runWithServerRef` there,
+ * since `enterWith` has no natural "scope end" and would leak across
+ * requests just like the old module-level singleton.
+ */
+export function bindServerRef(server: Server): void {
+  serverRefStore.enterWith(server);
+}
+
+/**
+ * Get the server bound to the current request's async context, or `null`
+ * if none is bound (e.g. called outside of a request/session, before a
+ * server ref has been established).
+ */
 export function getServerRef(): Server | null {
-  return _server;
+  return serverRefStore.getStore() ?? null;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,6 +32,7 @@ import {
   type GatewayCredentials,
   type ITGlueRegion,
 } from "./mcp-server.js";
+import { runWithServerRef } from "./utils/server-ref.js";
 
 export interface Env {
   ITGLUE_API_KEY?: string;
@@ -125,21 +126,28 @@ export default {
         }
       }
 
-      // Fresh server + transport per request (stateless).
+      // Fresh server + transport per request (stateless). The server is
+      // bound to the per-request async context (not a module-level
+      // global) so elicitation helpers resolve *this* request's server
+      // even after await gaps, and never a concurrent request's — see
+      // utils/server-ref.ts.
       const server = createMcpServer(credOverrides);
       const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true,
       });
-      await server.connect(transport);
 
-      try {
-        const response = await transport.handleRequest(request);
-        return withCors(response);
-      } finally {
-        await transport.close();
-        await server.close();
-      }
+      return runWithServerRef(server, async () => {
+        await server.connect(transport);
+
+        try {
+          const response = await transport.handleRequest(request);
+          return withCors(response);
+        } finally {
+          await transport.close();
+          await server.close();
+        }
+      });
     }
 
     return json({ error: "Not found", endpoints: ["/mcp", "/health"] }, 404);


### PR DESCRIPTION
## Summary

**P1 security fix — part of a 6-repo remediation wave (task_1784935505749), replicated from the reference PR halopsa-mcp#65.** The identical bug exists byte-for-byte in the sibling MCP sidecar repos (`atera-mcp`, `datto-rmm-mcp`, `superops-mcp`, `syncro-mcp`, and this one, `itglue-mcp`).

## The bug

`src/utils/server-ref.ts` implemented the "server reference" pattern used by MCP elicitation/confirmation helpers (`src/utils/elicitation.ts`: `elicitSelection` / `elicitText` / `elicitConfirmation`) as a **module-level singleton**:

```ts
let _server: Server | null = null;
export function setServerRef(server: Server): void { _server = server; }
export function getServerRef(): Server | null { return _server; }
```

`setServerRef(server)` was called synchronously inside `createMcpServer()` (`src/mcp-server.ts`), which — in gateway/HTTP mode — is invoked **once per inbound request** (`src/index.ts`, `src/worker.ts`). `getServerRef()` was then read back later, deep inside async tool handlers, **after arbitrary `await` gaps** (e.g. after awaiting an IT Glue API call, right before sending an elicitation/confirmation prompt).

**Misroute mechanism:** two concurrent tenant requests race through the shared global:
1. Tenant A's request creates server A, calls `setServerRef(serverA)`, and starts awaiting async work (e.g. an IT Glue API call inside a tool handler).
2. Before A resumes, tenant B's request arrives, creates server B, calls `setServerRef(serverB)` — **overwriting** the shared ref.
3. A's awaited work resolves; A calls `elicitConfirmation(...)`, which reads `getServerRef()` — and gets **server B**.
4. Tenant A's confirmation/elicitation prompt is sent down **tenant B's connection** instead of A's (or vice versa, depending on timing).

Same shared-mutable-state-across-await-gaps bug class as the credential-leak fixes (liongard-mcp#58, ninjaone-mcp#71) and the reference fix (halopsa-mcp#65), but in this repo's server/transport routing subsystem for elicitation, not credential/token caching.

## The fix

Replaced the module-level singleton with an `AsyncLocalStorage<Server>` context in `src/utils/server-ref.ts`:

- `runWithServerRef(server, fn)` — binds `server` to the async context for the duration of `fn` (including everything it awaits/schedules). Used for per-request transports: `src/index.ts` (Node HTTP handler wraps the existing `.then().catch()` connect chain) and `src/worker.ts` (Cloudflare Workers `handleMcp` wraps the connect/handleRequest/finally chain), one call per inbound request.
- `bindServerRef(server)` — binds `server` for the remainder of the current + all future async execution, via `AsyncLocalStorage.enterWith`. Used only in `src/index.ts`'s stdio path, which is single-session (one process = one caller, no concurrent tenants to isolate from).
- `getServerRef()` — reads from the ALS context instead of a module variable.

`createMcpServer()` (`src/mcp-server.ts`) no longer calls `setServerRef` at all — binding is now the caller's responsibility, at the point where the per-request (or per-session) scope is established.

**There is zero module-level mutable state holding a tenant/request-specific server or transport reference after this fix.**

### Structural note vs. the halopsa-mcp#65 template

itglue-mcp's transport entry points are structured slightly differently from halopsa's, so the wrap had to be adapted (not pasted verbatim):

- `src/index.ts`'s HTTP handler is fully callback-based (`server.connect(...).then(...).catch(...)`), not `async/await`. The whole `.then().catch()` chain is wrapped inside `runWithServerRef(server, () => { ... })` so the bound ALS context survives every gap between `connect()` resolving and the later `getServerRef()` call inside a tool handler.
- `src/worker.ts`'s `handleMcp` is `async/await` with a `try/finally`; here `runWithServerRef(server, async () => { ... })` wraps the `connect` → `handleRequest` → `finally { close }` block and its return value is passed straight back through.
- Unlike halopsa-mcp, itglue-mcp's gateway credentials are already passed as a **per-call function parameter** (`createMcpServer(credentialOverrides)`), not a second AsyncLocalStorage context — so there was no parallel credential-isolation fix needed here, only the server reference.

## Test

`src/__tests__/server-ref.test.ts` adds a regression test meeting the 3-part standard (forced interleave, per-tenant value assertions, no swallowed assertions), structurally identical to halopsa-mcp#65's:

1. **Forced interleave (deterministic, not timing-based):** a manually-resolved "gate" promise. Tenant A binds its server (`runWithServerRef(serverA, ...)`) and suspends on `await gate.promise` — simulating an in-flight IT Glue API call. Tenant B's **entire** request (bind, elicit, resolve) then runs to completion while A is still suspended — exactly like a second concurrent HTTP request racing in. Only then is the gate resolved and A allowed to resume and call `elicitConfirmation`.
2. **Per-tenant value assertions:** each tenant gets its own mock `Server` with its own `elicitInput` spy (tagged `tenantId`). The test asserts, by value, that tenant A's message was received by tenant A's mock (`serverA.elicitInput`) and tenant B's by tenant B's mock — plus explicit negative checks that A's message never reached B's mock and vice versa.
3. **No swallowed assertions:** all assertions are made after `await`ing both tenant promises to completion; none are inside a callback that could silently never fire.

**Verified the test actually catches the bug:** temporarily reinstated a module-singleton implementation behind the same function names (`runWithServerRef` / `bindServerRef` / `getServerRef`) and reran just this test file:

```
FAIL  src/__tests__/server-ref.test.ts > ... forced deterministic interleave ...
AssertionError: expected 'tenant-B' to be 'tenant-A' // Object.is equality
```

— the exact predicted misroute symptom: tenant A's resumed continuation reads tenant B's server. Restored the ALS-based fix and reran the full suite: green.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 220/220 passing (216 pre-existing + 4 new in `server-ref.test.ts`)
- [x] New regression test verified to **fail** against a reinstated module-singleton implementation, with the exact predicted wrong-tenant-routing symptom (`expected 'tenant-B' to be 'tenant-A'`)
- [x] New regression test verified to **pass** against the ALS-based fix
- [x] CHANGELOG.md updated under `### Security` (Keep a Changelog format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)