### PR TITLE
fix(security): enforce gateway S2S verification (gateway#377 parity)

### DIFF
--- a/src/__tests__/s2s-verify.test.ts
+++ b/src/__tests__/s2s-verify.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { createHmac } from "node:crypto";
+import { verifyS2sHeader } from "../s2s-verify.js";
+
+function deriveRecipientSubkey(masterSecret: string, slug: string): string {
+  return createHmac("sha256", masterSecret).update(`s2s-recipient:${slug}`).digest("hex");
+}
+function mintHeader(secret: string, unixSeconds: number): string {
+  const message = `t=${unixSeconds}`;
+  const hex = createHmac("sha256", secret).update(message).digest("hex");
+  return `${message},v1=${hex}`;
+}
+
+describe("verifyS2sHeader", () => {
+  const MASTER = "test-master-secret-do-not-use-in-prod";
+  const ownSubkey = deriveRecipientSubkey(MASTER, "itglue");
+  const siblingSubkey = deriveRecipientSubkey(MASTER, "kaseya-vsa");
+
+  it("accepts a header minted with this vendor's own derived subkey", () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now), ownSubkey)).toBe(true);
+  });
+  it("REJECTS a header minted for a different vendor's derived subkey (recipient-binding proof)", () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(verifyS2sHeader(mintHeader(siblingSubkey, now), ownSubkey)).toBe(false);
+  });
+  it("rejects a stale timestamp outside the skew window", () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now - 301), ownSubkey)).toBe(false);
+  });
+  it("rejects a future timestamp outside the skew window", () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now + 301), ownSubkey)).toBe(false);
+  });
+  it("accepts a timestamp at the edge of the skew window", () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now - 300), ownSubkey)).toBe(true);
+  });
+  it("rejects a malformed header value", () => {
+    expect(verifyS2sHeader("not-a-valid-header", ownSubkey)).toBe(false);
+  });
+  it("rejects a missing header", () => {
+    expect(verifyS2sHeader(undefined, ownSubkey)).toBe(false);
+  });
+  it("rejects when the secret is empty (dark-by-default guarantee)", () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now), "")).toBe(false);
+  });
+  it("rejects a tampered signature", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const header = mintHeader(ownSubkey, now);
+    const tampered = header.slice(0, -1) + (header.endsWith("0") ? "1" : "0");
+    expect(verifyS2sHeader(tampered, ownSubkey)).toBe(false);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ import {
   type ITGlueRegion,
 } from "./mcp-server.js";
 import { runWithServerRef, bindServerRef } from "./utils/server-ref.js";
+import { verifyS2sHeader, S2S_HEADER } from "./s2s-verify.js";
+
+const S2S_SECRET = process.env.CONDUIT_S2S_SECRET || "";
 
 // Re-export the shared factory + IT Glue client/helpers so existing consumers
 // (and tests) that import from the package entry keep working after the
@@ -89,6 +92,16 @@ async function startHttpTransport(): Promise<void> {
 
     // MCP endpoint — stateless: fresh server + transport per request
     if (url.pathname === "/mcp") {
+      if (S2S_SECRET && !verifyS2sHeader(req.headers[S2S_HEADER] as string | undefined, S2S_SECRET)) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: "Missing or invalid X-Gateway-S2S header: this endpoint only accepts requests signed by the gateway.",
+          })
+        );
+        return;
+      }
+
       // Only POST is supported in stateless mode
       if (req.method !== "POST") {
         res.writeHead(405, { "Content-Type": "application/json" });

--- a/src/s2s-verify.ts
+++ b/src/s2s-verify.ts
@@ -1,0 +1,43 @@
+/**
+ * Verifies the conduit gateway's service-to-service auth header
+ * (gateway#377 parity — closes the confused-deputy gap where a compromised
+ * sibling sidecar in the shared ACA environment could otherwise impersonate
+ * the gateway to this container).
+ *
+ * This is a near-verbatim port of conduit's `verifyS2sHeader`
+ * (src/proxy/s2s.ts) — intentionally unchanged logic, ported once and kept
+ * in sync. `secret` is treated as an opaque value: since gateway#377
+ * Finding B, the gateway derives a per-vendor subkey from its master
+ * secret and this container is provisioned (via CONDUIT_S2S_SECRET) with
+ * only its own derived value, never the raw master — a sibling sidecar
+ * holds a DIFFERENT derived value and cannot forge a header that verifies
+ * here. This function doesn't need to know that; it just checks whatever
+ * secret it's handed.
+ *
+ * Empty secret => always returns false. The caller is expected to treat an
+ * empty CONDUIT_S2S_SECRET as "S2S enforcement disabled" (dark-by-default,
+ * matches the dormant/pre-provisioning state) rather than calling this at
+ * all — see the enforcement check in index.ts.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/** Request header carrying the S2S proof. Node lowercases incoming header names. */
+export const S2S_HEADER = "x-gateway-s2s";
+
+const HEADER_VALUE_RE = /^t=(\d{1,15}),v1=([0-9a-f]{64})$/;
+
+export function verifyS2sHeader(
+  headerValue: string | undefined,
+  secret: string,
+  maxSkewSeconds = 300
+): boolean {
+  if (!secret || !headerValue) return false;
+  const match = HEADER_VALUE_RE.exec(headerValue);
+  if (!match) return false;
+  const t = Number(match[1]);
+  if (!Number.isSafeInteger(t)) return false;
+  if (Math.abs(Math.floor(Date.now() / 1000) - t) > maxSkewSeconds) return false;
+  const expected = createHmac("sha256", secret).update(`t=${t}`).digest();
+  const provided = Buffer.from(match[2], "hex");
+  return provided.length === expected.length && timingSafeEqual(provided, expected);
+}


### PR DESCRIPTION
## Summary

Mechanical-wave port of the S2S gateway-verification pattern already live-validated on xero-mcp#54, mimecast-mcp#55, and liongard-mcp#60. This closes the confused-deputy gap where a compromised sibling sidecar in the shared ACA environment could otherwise impersonate the gateway to this container.

- Adds `src/s2s-verify.ts` — byte-for-byte port of conduit's `verifyS2sHeader` (src/proxy/s2s.ts).
- In `src/index.ts`, the S2S check is inserted as the **absolute first statement** inside the `if (url.pathname === "/mcp")` block — before the existing POST-method check and before all inline credential-header extraction (`x-itglue-api-key`, `x-itglue-jwt`, etc.).
- `CONDUIT_S2S_SECRET` unset/empty ⇒ enforcement is dark-by-default (matches the pre-provisioning state); the guard only activates once the secret is provisioned.

## Survey note deviations

None. The survey notes for this repo were accurate: no shared credential-extraction helper exists (headers are read inline in `src/index.ts`), and a POST-method check does run before credential extraction inside the `/mcp` block — confirmed by reading the file directly. The guard was inserted before both, as required. `src/worker.ts` (Cloudflare Workers entrypoint) was left untouched — the Dockerfile `CMD ["node", "dist/index.js"]` confirms `src/index.ts` is the production entrypoint, and worker.ts is out of scope for this rollout.

## Build/test results (observed this session)

- `npx tsc --noEmit`: clean, exit 0.
- `npm run build`: clean, exit 0.
- `npm test` (vitest): **229/229 passing**, 5/5 test files, run and re-confirmed 4 times in this session (including once with a 425s import phase under heavy sandbox load) — all green.
- Tests present and run locally (229/229 passing); **NOT currently CI-gated** — this repo's `.github/workflows/ci.yml` runs only `npm run typecheck` and `npm run build` (no `npm test` step), and `.github/workflows/mcp-assert.yml` runs a contract/canary check only, not vitest. Fleet-wide CI-hygiene item (wiring vitest into CI) tracked separately (murph).

## Note on a flake found and fixed during porting

The initial draft of `s2s-verify.test.ts` captured `now = Math.floor(Date.now() / 1000)` once at the `describe`-block level and reused it across timestamp-boundary assertions. Under heavy load (this session had many concurrent clones/builds running), the gap between test definition and execution could drift enough wall-clock time to push the exact-300s-skew-boundary assertions over the line, causing 2 of 9 tests to intermittently fail. Fixed by computing `now` fresh as the first line inside every `it()` that uses it, eliminating the drift window. Re-confirmed green afterward, including under an even heavier load (425s import phase) than the run that originally exposed the flake.

---

Do not merge without Walter + boss review — auth surface, heightened-review-and-narrate tier.
