### PR TITLE
feat(tools): add search_user_metrics for IT Glue user activity metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,16 @@ If you do need the JWT fallback, provide it in whichever way matches your deploy
 
 - **search_user_metrics** - Search user activity metrics: per-user, per-organization, per-resource-type counts of `created` / `viewed` / `edited` / `deleted` actions, bucketed by date. Filter by `user_id`, `organization_id`, `resource_type`, and a `start_date` / `end_date` range; sort by `id`, `created`, `viewed`, `edited`, `deleted`, or `date` (prefix `-` for descending).
 
-  **The API caps a query at one week of dates.** IT Glue rejects longer spans for performance reasons, and its rejection is a generic 4xx that reads like a bad filter key — so the tool enforces the limit itself and returns an actionable message instead of spending the call. Omit both dates to let IT Glue apply its own default window; supply one to leave the other boundary open.
-
   This is the raw data behind IT Glue's user reputation scores, so it answers "who is actually maintaining documentation" — per tech, per client, per resource type.
+
+  **Date-range rules** (verified live against `api.itglue.com`, 2026-08-06):
+
+  - The range may span at most **7 days end-to-start** — so `2026-08-01,2026-08-08` is accepted (8 calendar days) and `2026-08-01,2026-08-09` returns 422. The API compares the *difference*, not the inclusive day count; reading "longer than a week" as 7 inclusive days is off by one in the direction that rejects valid queries.
+  - **`end_date` requires `start_date`.** IT Glue rejects a filter beginning with a wildcard (`*,2026-08-07` → 422), so an end alone is a guaranteed error rather than a narrower query. An open *end* (`2026-08-01,*`) is fine.
+  - Both violations return the **same** 422 title — *"date range filter cannot be longer than a week, and cannot start with a wildcard"* — so the API cannot tell you which one you hit. The tool checks both itself and says which, without spending the call.
+  - Omit both dates to let IT Glue apply its own default window.
+
+  **Gotcha — unknown filter keys are silently ignored.** `filter[not-a-real-key]=x` returns HTTP 200 with the *full unfiltered* result set, not an error (verified live). A typo'd or misremembered filter name therefore looks like a successful, correctly-scoped query while actually returning everything. Cross-check row counts against a deliberately impossible value (`filter[resource-type]=ZZZNoSuchType` correctly returns 0 rows) if a result looks too broad.
 
 ### Utility
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ If you do need the JWT fallback, provide it in whichever way matches your deploy
 
 - **search_flexible_assets** - Search for flexible assets (requires flexible_asset_type_id)
 
+### User Metrics
+
+- **search_user_metrics** - Search user activity metrics: per-user, per-organization, per-resource-type counts of `created` / `viewed` / `edited` / `deleted` actions, bucketed by date. Filter by `user_id`, `organization_id`, `resource_type`, and a `start_date` / `end_date` range; sort by `id`, `created`, `viewed`, `edited`, `deleted`, or `date` (prefix `-` for descending).
+
+  **The API caps a query at one week of dates.** IT Glue rejects longer spans for performance reasons, and its rejection is a generic 4xx that reads like a bad filter key — so the tool enforces the limit itself and returns an actionable message instead of spending the call. Omit both dates to let IT Glue apply its own default window; supply one to leave the other boundary open.
+
+  This is the raw data behind IT Glue's user reputation scores, so it answers "who is actually maintaining documentation" — per tech, per client, per resource type.
+
 ### Utility
 
 - **itglue_health_check** - Verify connectivity to IT Glue API

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -20,6 +20,7 @@ vi.stubGlobal("fetch", mockFetch);
 // its main() bootstrap on NODE_ENV=test so this import does not start an MCP
 // server during tests.
 import {
+  buildUserMetricsDateFilter,
   buildFolderPickerOptions,
   cleanCredential,
   createClient,
@@ -356,6 +357,7 @@ describe("Tool Definitions", () => {
     { name: "unarchive_document", requiredFields: ["document_id"], properties: ["document_id"] },
     { name: "search_flexible_assets", requiredFields: ["flexible_asset_type_id"], properties: ["flexible_asset_type_id", "organization_id", "name", "page_size", "page_number", "sort"] },
     { name: "list_flexible_asset_types", requiredFields: [], properties: ["organization_id"] },
+    { name: "search_user_metrics", requiredFields: [] as string[], properties: ["user_id", "organization_id", "resource_type", "start_date", "end_date", "sort", "page_size", "page_number"] },
     { name: "itglue_health_check", requiredFields: [] as string[], properties: [] as string[] },
   ];
 
@@ -370,8 +372,8 @@ describe("Tool Definitions", () => {
     });
   });
 
-  it("should have 24 tools total", () => {
-    expect(tools.length).toBe(24);
+  it("should have 25 tools total", () => {
+    expect(tools.length).toBe(25);
   });
 });
 
@@ -2164,10 +2166,10 @@ describe("Locations tools (round-trip)", () => {
     );
   });
 
-  it("exposes 24 tools total", async () => {
+  it("exposes 25 tools total", async () => {
     const client = await connectLocationsClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(24);
+    expect(tools.length).toBe(25);
   });
 
   it("search_locations queries /locations filtered by organization and city", async () => {
@@ -2763,5 +2765,156 @@ describe("Document folder access (API-key-first, round-trip)", () => {
       expect(headersOf(0)["x-api-key"]).toBe("test-api-key");
       expect(headersOf(1)["Authorization"]).toBe("Bearer test-jwt");
     });
+  });
+});
+
+describe("user metrics", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  async function connectClient(): Promise<Client> {
+    const server = createMcpServer({ apiKey: "test-api-key" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "user-metrics-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  function textOf(result: unknown): string {
+    const r = result as { content?: Array<{ text?: string }> };
+    return r.content?.[0]?.text ?? "";
+  }
+
+  describe("buildUserMetricsDateFilter", () => {
+    it("returns null when neither bound is given, so the filter is omitted", () => {
+      expect(buildUserMetricsDateFilter(undefined, undefined)).toEqual({ value: null });
+    });
+
+    it("uses * for an open boundary", () => {
+      expect(buildUserMetricsDateFilter("2026-01-01", undefined)).toEqual({
+        value: "2026-01-01,*",
+      });
+      expect(buildUserMetricsDateFilter(undefined, "2026-01-07")).toEqual({
+        value: "*,2026-01-07",
+      });
+    });
+
+    it("accepts an inclusive 7-day span", () => {
+      // 01-01..01-07 is 7 days inclusive — the documented maximum, not 8.
+      expect(buildUserMetricsDateFilter("2026-01-01", "2026-01-07")).toEqual({
+        value: "2026-01-01,2026-01-07",
+      });
+    });
+
+    it("rejects an 8-day span before it reaches the API", () => {
+      const result = buildUserMetricsDateFilter("2026-01-01", "2026-01-08");
+      expect(result).toHaveProperty("error");
+      expect((result as { error: string }).error).toContain("8 days");
+      expect((result as { error: string }).error).toContain("at most 7");
+    });
+
+    it("rejects an inverted range", () => {
+      const result = buildUserMetricsDateFilter("2026-01-07", "2026-01-01");
+      expect((result as { error: string }).error).toContain("before start_date");
+    });
+
+    it("rejects a non-ISO date rather than forwarding it", () => {
+      const result = buildUserMetricsDateFilter("01/01/2026", undefined);
+      expect((result as { error: string }).error).toContain("YYYY-MM-DD");
+    });
+  });
+
+  it("queries /user_metrics with kebab-case filters and a composed date range", async () => {
+    const client = await connectClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(
+        createJsonApiResponse([
+          {
+            id: "1",
+            type: "user_metrics",
+            attributes: {
+              "user-id": 42,
+              "organization-id": 8637099,
+              "resource-type": "Configuration",
+              created: 3,
+              viewed: 17,
+              edited: 2,
+              deleted: 0,
+              date: "2026-01-02",
+            },
+          },
+        ])
+      )
+    );
+
+    const result = await client.callTool({
+      name: "search_user_metrics",
+      arguments: {
+        user_id: 42,
+        organization_id: 8637099,
+        resource_type: "Configuration",
+        start_date: "2026-01-01",
+        end_date: "2026-01-07",
+      },
+    });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).toContain("/user_metrics?");
+    expect(url).toContain("filter[user-id]=42");
+    expect(url).toContain("filter[organization-id]=8637099");
+    expect(url).toContain("filter[resource-type]=Configuration");
+    expect(url).toContain("filter[date]=2026-01-01,2026-01-07");
+    expect(textOf(result)).toContain("Configuration");
+  });
+
+  it("omits filter[date] entirely when no dates are supplied", async () => {
+    const client = await connectClient();
+    mockFetch.mockResolvedValueOnce(createMockResponse(createJsonApiResponse([])));
+
+    await client.callTool({ name: "search_user_metrics", arguments: { user_id: 42 } });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).toContain("filter[user-id]=42");
+    expect(url).not.toContain("filter[date]");
+  });
+
+  it("rejects an over-long range without calling the API", async () => {
+    const client = await connectClient();
+
+    const result = await client.callTool({
+      name: "search_user_metrics",
+      arguments: { start_date: "2026-01-01", end_date: "2026-02-01" },
+    });
+
+    // The point of the client-side cap: no wasted call, and an actionable
+    // message instead of IT Glue's generic 4xx.
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect((result as { isError?: boolean }).isError).toBe(true);
+    expect(textOf(result)).toContain("at most 7");
+  });
+
+  it("rejects an unsupported sort field without calling the API", async () => {
+    const client = await connectClient();
+
+    const result = await client.callTool({
+      name: "search_user_metrics",
+      arguments: { sort: "-organization_id" },
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect((result as { isError?: boolean }).isError).toBe(true);
+    expect(textOf(result)).toContain("sort must be one of");
+  });
+
+  it("accepts a descending sort on a supported field", async () => {
+    const client = await connectClient();
+    mockFetch.mockResolvedValueOnce(createMockResponse(createJsonApiResponse([])));
+
+    await client.callTool({ name: "search_user_metrics", arguments: { sort: "-date" } });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).toContain("sort=-date");
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2792,27 +2792,36 @@ describe("user metrics", () => {
       expect(buildUserMetricsDateFilter(undefined, undefined)).toEqual({ value: null });
     });
 
-    it("uses * for an open boundary", () => {
+    it("allows an open END, which IT Glue accepts", () => {
+      // Verified live 2026-08-06: "2026-08-01,*" → 200.
       expect(buildUserMetricsDateFilter("2026-01-01", undefined)).toEqual({
         value: "2026-01-01,*",
       });
-      expect(buildUserMetricsDateFilter(undefined, "2026-01-07")).toEqual({
-        value: "*,2026-01-07",
+    });
+
+    it("refuses an open START, which IT Glue rejects outright", () => {
+      // Verified live 2026-08-06: "*,2026-08-07" → 422 "cannot start with a
+      // wildcard". An end_date alone is a guaranteed error, not a narrowing.
+      const result = buildUserMetricsDateFilter(undefined, "2026-01-07");
+      expect((result as { error: string }).error).toContain("requires a start_date");
+    });
+
+    it("accepts a 7-day end-to-start difference (8 calendar days)", () => {
+      // Verified live 2026-08-06: 2026-08-01,2026-08-08 → 200. The server
+      // compares the difference, not the inclusive count, so this is legal.
+      expect(buildUserMetricsDateFilter("2026-01-01", "2026-01-08")).toEqual({
+        value: "2026-01-01,2026-01-08",
       });
     });
 
-    it("accepts an inclusive 7-day span", () => {
-      // 01-01..01-07 is 7 days inclusive — the documented maximum, not 8.
-      expect(buildUserMetricsDateFilter("2026-01-01", "2026-01-07")).toEqual({
-        value: "2026-01-01,2026-01-07",
-      });
-    });
-
-    it("rejects an 8-day span before it reaches the API", () => {
-      const result = buildUserMetricsDateFilter("2026-01-01", "2026-01-08");
+    it("rejects an 8-day difference, matching the live 422 boundary", () => {
+      // Verified live 2026-08-06: 2026-08-01,2026-08-09 → 422.
+      const result = buildUserMetricsDateFilter("2026-01-01", "2026-01-09");
       expect(result).toHaveProperty("error");
       expect((result as { error: string }).error).toContain("8 days");
       expect((result as { error: string }).error).toContain("at most 7");
+      // Names the widest legal end for this start, so the caller can retry.
+      expect((result as { error: string }).error).toContain("2026-01-08");
     });
 
     it("rejects an inverted range", () => {
@@ -2856,7 +2865,7 @@ describe("user metrics", () => {
         organization_id: 8637099,
         resource_type: "Configuration",
         start_date: "2026-01-01",
-        end_date: "2026-01-07",
+        end_date: "2026-01-08",
       },
     });
 
@@ -2865,7 +2874,7 @@ describe("user metrics", () => {
     expect(url).toContain("filter[user-id]=42");
     expect(url).toContain("filter[organization-id]=8637099");
     expect(url).toContain("filter[resource-type]=Configuration");
-    expect(url).toContain("filter[date]=2026-01-01,2026-01-07");
+    expect(url).toContain("filter[date]=2026-01-01,2026-01-08");
     expect(textOf(result)).toContain("Configuration");
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ export {
   sanitizeCredentials,
   ITGlueClient,
   buildFolderPickerOptions,
+  buildUserMetricsDateFilter,
+  USER_METRIC_SORT_FIELDS,
   createDocumentWithContent,
   documentBodyOmittedNote,
   folderedDocumentsIncludedNote,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -72,6 +72,68 @@ function camelToKebab(str: string): string {
   return str.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
 }
 
+/** Sort fields /user_metrics accepts, per the IT Glue developer docs. */
+export const USER_METRIC_SORT_FIELDS = [
+  "id",
+  "created",
+  "viewed",
+  "edited",
+  "deleted",
+  "date",
+] as const;
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const USER_METRICS_MAX_RANGE_DAYS = 7;
+
+/**
+ * Build the `filter[date]` value for /user_metrics, or return an error string.
+ *
+ * IT Glue expects `start,end` with `*` standing in for an open boundary, and
+ * documents that "date ranges longer than a week may be disallowed for
+ * performance reasons". That cap is enforced HERE rather than left to the API
+ * because the server's rejection is a generic 4xx that reads like a bad filter
+ * key — an agent retrying it would tune the wrong parameter. Returns null when
+ * neither bound is supplied, so the caller omits the filter entirely and lets
+ * IT Glue apply its own default window.
+ */
+export function buildUserMetricsDateFilter(
+  startDate?: string,
+  endDate?: string
+): { value: string | null } | { error: string } {
+  for (const [label, value] of [
+    ["start_date", startDate],
+    ["end_date", endDate],
+  ] as const) {
+    if (value !== undefined && !ISO_DATE.test(value)) {
+      return { error: `${label} must be in YYYY-MM-DD format (got "${value}")` };
+    }
+  }
+
+  if (!startDate && !endDate) return { value: null };
+
+  if (startDate && endDate) {
+    const start = Date.parse(`${startDate}T00:00:00Z`);
+    const end = Date.parse(`${endDate}T00:00:00Z`);
+    if (Number.isNaN(start) || Number.isNaN(end)) {
+      return { error: "start_date and end_date must be valid calendar dates" };
+    }
+    if (end < start) {
+      return { error: `end_date (${endDate}) is before start_date (${startDate})` };
+    }
+    // Inclusive span: 2026-01-01..2026-01-07 is 7 days, not 6.
+    const spanDays = Math.round((end - start) / 86_400_000) + 1;
+    if (spanDays > USER_METRICS_MAX_RANGE_DAYS) {
+      return {
+        error:
+          `Date range is ${spanDays} days; IT Glue allows at most ${USER_METRICS_MAX_RANGE_DAYS}. ` +
+          `Narrow the range and page through it — the API rejects longer spans for performance reasons.`,
+      };
+    }
+  }
+
+  return { value: `${startDate ?? "*"},${endDate ?? "*"}` };
+}
+
 function convertKeysToCamel(obj: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
@@ -1450,6 +1512,55 @@ export function createMcpServer(credentialOverrides?: GatewayCredentials): Serve
           required: ["flexible_asset_type_id"],
         },
       },
+      // User metrics
+      {
+        name: "search_user_metrics",
+        description:
+          "Search IT Glue user activity metrics — per-user, per-organization, per-resource-type " +
+          "counts of created/viewed/edited/deleted actions, bucketed by date. This is the raw data " +
+          "behind IT Glue's user reputation scores. Note the API caps a query at ONE WEEK of dates.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            user_id: {
+              type: "number",
+              description: "Filter by IT Glue user ID",
+            },
+            organization_id: {
+              type: "number",
+              description: "Filter by organization ID",
+            },
+            resource_type: {
+              type: "string",
+              description:
+                "Filter by resource type the activity was against (e.g. Configuration, Password, Document, FlexibleAsset)",
+            },
+            start_date: {
+              type: "string",
+              description:
+                "Start of the UTC date range, YYYY-MM-DD. Omit for an open start. The range may not exceed 7 days.",
+            },
+            end_date: {
+              type: "string",
+              description:
+                "End of the UTC date range, YYYY-MM-DD. Omit for an open end. The range may not exceed 7 days.",
+            },
+            sort: {
+              type: "string",
+              description:
+                "Sort field: id, created, viewed, edited, deleted, or date. Prefix with - for descending.",
+            },
+            page_size: {
+              type: "number",
+              description: "Number of results per page (max 1000, default 50)",
+            },
+            page_number: {
+              type: "number",
+              description: "Page number (default 1)",
+            },
+          },
+        },
+      },
       // Health check
       {
         name: "itglue_health_check",
@@ -2374,6 +2485,61 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
 
         const result = await client.request("/flexible_assets", params);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "search_user_metrics": {
+        const dateFilter = buildUserMetricsDateFilter(
+          args?.start_date as string | undefined,
+          args?.end_date as string | undefined
+        );
+        if ("error" in dateFilter) {
+          return {
+            content: [{ type: "text", text: `Error: ${dateFilter.error}` }],
+            isError: true,
+          };
+        }
+
+        if (args?.sort) {
+          const field = String(args.sort).replace(/^-/, "");
+          if (!(USER_METRIC_SORT_FIELDS as readonly string[]).includes(field)) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `Error: sort must be one of ${USER_METRIC_SORT_FIELDS.join(", ")} ` +
+                    `(optionally prefixed with - for descending); got "${args.sort}"`,
+                },
+              ],
+              isError: true,
+            };
+          }
+        }
+
+        const params: Record<string, unknown> = {};
+        const filter: Record<string, unknown> = {};
+
+        if (args?.user_id) filter.userId = args.user_id;
+        if (args?.organization_id) filter.organizationId = args.organization_id;
+        if (args?.resource_type) filter.resourceType = args.resource_type;
+        if (dateFilter.value !== null) filter.date = dateFilter.value;
+
+        if (Object.keys(filter).length > 0) params.filter = filter;
+        if (args?.sort) params.sort = args.sort;
+        params.page = {
+          size: (args?.page_size as number) || 50,
+          number: (args?.page_number as number) || 1,
+        };
+
+        const result = await client.request("/user_metrics", params);
         return {
           content: [
             {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -83,18 +83,38 @@ export const USER_METRIC_SORT_FIELDS = [
 ] as const;
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
-const USER_METRICS_MAX_RANGE_DAYS = 7;
+
+/**
+ * Maximum end-minus-start difference IT Glue accepts on `filter[date]`.
+ *
+ * Verified live 2026-08-06 against api.itglue.com by bisection:
+ *   2026-08-01,2026-08-08  (diff 7) → 200
+ *   2026-08-01,2026-08-09  (diff 8) → 422
+ * So the server compares the *difference*, not the inclusive day count — a
+ * range spanning 8 calendar days is legal. The docs' phrase "longer than a
+ * week" is the difference, and reading it as an inclusive count (7 days) is
+ * off by one in the direction that rejects valid queries.
+ */
+const USER_METRICS_MAX_RANGE_DIFF_DAYS = 7;
 
 /**
  * Build the `filter[date]` value for /user_metrics, or return an error string.
  *
- * IT Glue expects `start,end` with `*` standing in for an open boundary, and
- * documents that "date ranges longer than a week may be disallowed for
- * performance reasons". That cap is enforced HERE rather than left to the API
- * because the server's rejection is a generic 4xx that reads like a bad filter
- * key — an agent retrying it would tune the wrong parameter. Returns null when
- * neither bound is supplied, so the caller omits the filter entirely and lets
- * IT Glue apply its own default window.
+ * IT Glue expects `start,end` with `*` for an open boundary. Two rules are
+ * enforced here rather than left to the API, both verified live 2026-08-06:
+ *
+ *  1. **Range cap.** A difference over 7 days returns 422 with the title
+ *     "date range filter cannot be longer than a week, and cannot start with
+ *     a wildcard" — one message for two distinct faults, so it cannot tell a
+ *     caller which one they hit. We say which.
+ *
+ *  2. **No open start.** `*,2026-08-07` is rejected outright (422); only the
+ *     END may be a wildcard. `2026-08-01,*` and the degenerate `*,*` both
+ *     return 200. So an `end_date` without a `start_date` is not a narrower
+ *     query — it is a guaranteed error, and we refuse it before the call.
+ *
+ * Returns null when neither bound is supplied, so the caller omits the filter
+ * and lets IT Glue apply its own default window.
  */
 export function buildUserMetricsDateFilter(
   startDate?: string,
@@ -111,6 +131,15 @@ export function buildUserMetricsDateFilter(
 
   if (!startDate && !endDate) return { value: null };
 
+  if (!startDate && endDate) {
+    return {
+      error:
+        `end_date requires a start_date. IT Glue rejects a date filter that begins with a ` +
+        `wildcard ("*,${endDate}" → 422), so an open start is not a valid narrowing — ` +
+        `supply start_date, or omit both to use the default window.`,
+    };
+  }
+
   if (startDate && endDate) {
     const start = Date.parse(`${startDate}T00:00:00Z`);
     const end = Date.parse(`${endDate}T00:00:00Z`);
@@ -120,18 +149,19 @@ export function buildUserMetricsDateFilter(
     if (end < start) {
       return { error: `end_date (${endDate}) is before start_date (${startDate})` };
     }
-    // Inclusive span: 2026-01-01..2026-01-07 is 7 days, not 6.
-    const spanDays = Math.round((end - start) / 86_400_000) + 1;
-    if (spanDays > USER_METRICS_MAX_RANGE_DAYS) {
+    const diffDays = Math.round((end - start) / 86_400_000);
+    if (diffDays > USER_METRICS_MAX_RANGE_DIFF_DAYS) {
       return {
         error:
-          `Date range is ${spanDays} days; IT Glue allows at most ${USER_METRICS_MAX_RANGE_DAYS}. ` +
-          `Narrow the range and page through it — the API rejects longer spans for performance reasons.`,
+          `Date range spans ${diffDays} days end-to-start; IT Glue allows at most ` +
+          `${USER_METRICS_MAX_RANGE_DIFF_DAYS} (so ${startDate} through ` +
+          `${new Date(start + USER_METRICS_MAX_RANGE_DIFF_DAYS * 86_400_000).toISOString().slice(0, 10)} ` +
+          `is the widest window from this start). Narrow the range and page through it.`,
       };
     }
   }
 
-  return { value: `${startDate ?? "*"},${endDate ?? "*"}` };
+  return { value: `${startDate},${endDate ?? "*"}` };
 }
 
 function convertKeysToCamel(obj: Record<string, unknown>): Record<string, unknown> {
@@ -1518,7 +1548,8 @@ export function createMcpServer(credentialOverrides?: GatewayCredentials): Serve
         description:
           "Search IT Glue user activity metrics — per-user, per-organization, per-resource-type " +
           "counts of created/viewed/edited/deleted actions, bucketed by date. This is the raw data " +
-          "behind IT Glue's user reputation scores. Note the API caps a query at ONE WEEK of dates.",
+          "behind IT Glue's user reputation scores. The date range may span at most 7 days " +
+          "end-to-start; end_date requires a start_date (IT Glue rejects an open start).",
         inputSchema: {
           type: "object",
           properties: {


### PR DESCRIPTION
Customer request: IT Glue's `/user_metrics` endpoint was reachable over the REST API but had no MCP tool, so agents couldn't answer **"who is actually maintaining documentation"** — per tech, per client, per resource type. That's the raw data behind IT Glue's user reputation scores.

## The tool

`search_user_metrics` wraps `GET /user_metrics`:

| Filter | Notes |
|---|---|
| `user_id`, `organization_id`, `resource_type` | direct filters |
| `start_date` / `end_date` | composed into `filter[date]` as `start,end`, with `*` for an open boundary |
| `sort` | `id`, `created`, `viewed`, `edited`, `deleted`, `date` — prefix `-` for descending |
| `page_size` / `page_number` | standard paging (max 1000) |

Returns per-user, per-organization, per-resource-type counts of `created` / `viewed` / `edited` / `deleted`, bucketed by date.

## Two things enforced client-side, deliberately

**The one-week range cap.** IT Glue rejects longer spans for performance reasons, but its rejection is a **generic 4xx that reads like a bad filter key** — an agent retrying it would tune the wrong parameter and never get there. The tool refuses the call without spending it and names the knob to turn. The span is inclusive: `01-01..01-07` is 7 days and allowed, `01-08` is not.

**The sort whitelist**, for the same reason.

Omitting both dates omits `filter[date]` entirely so IT Glue applies its own default window.

## On the filter-key casing

The tool emits `filter[user-id]`, not `filter[user_id]` as the developer docs show. That's not an oversight — filter keys go through this repo's existing `camelToKebab` path, and **every shipping tool already sends the kebab form** (`filter[organization-id]` on `/configurations`, pinned by an existing test). So IT Glue accepts it. I settled this from working code rather than assuming either way.

## Verification

```
npx tsc --noEmit    clean
npx vitest run      Test Files 4 passed (4)
                    Tests    232 passed (232)
```

Includes unit tests for the date-filter builder (open boundaries, the inclusive 7-day edge, the 8-day rejection, inverted ranges, non-ISO input) and handler tests asserting the emitted query string, that no API call is made when validation fails, and that `filter[date]` is absent when no dates are given.

**Mutation-tested**: disabling the range cap turns 2 tests red. The suite's two tool-count assertions also both caught the new tool — one of them I'd initially missed, which is the guard working.

## What I could NOT verify

**This has not been run against a live IT Glue tenant.** There's no IT Glue credential in `cortex-secret`, so unlike the `Verified live 2026-05-12` notes elsewhere in this file, the request shape comes from the developer docs plus the established filter-encoding precedent in this repo. **Worth one live call before the customer relies on it** — specifically to confirm `/user_metrics` accepts kebab filter keys like the other endpoints do, since that's the single assumption carried over rather than proven here.