### PR TITLE
ci(deps): ignore typescript major-version bumps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,15 @@ updates:
     # Production MAJORS are intentionally NOT grouped → individual PRs, held for
     # human review (never auto-merged).
 
+    ignore:
+      # typescript 7.x breaks this fleet's toolchain: DTS emit (tsup/rollup-plugin-dts
+      # TS5101 baseUrl-deprecated-as-error), and typescript-eslint (still <6.1.0 as of
+      # 8.66.0, no TS7 support yet). Has broken main 3x on some repos because Dependabot
+      # has no memory of a prior manual revert and just re-proposes the same major again.
+      # Deliberate hold, not a permanent blind -- remove once typescript-eslint + the
+      # tsup/DTS toolchain support TS7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Why

TypeScript 7.x breaks this fleet's toolchain right now:

- DTS emit via tsup/rollup-plugin-dts throws `TS5101` ("baseUrl is deprecated") as a **hard error** under TS7.
- `typescript-eslint` still caps its peer range below `typescript@6.1.0` as of its latest `8.66.0` release — no TS7 support yet.

Several repos in the fleet have already had this manually fixed once (typescript pinned back down) only to have Dependabot re-propose and re-merge the exact same breaking major bump later, because Dependabot has no memory of a prior manual revert. This broke `main` on 5 repos in one night.

## What

Adds an `ignore:` rule (sibling to the existing `groups:` block) on the npm `updates:` entry to stop Dependabot from proposing `typescript` **major**-version bumps at all, until the toolchain catches up. Minor/patch typescript updates are unaffected and continue to flow through the existing `dev-dependencies` group as before.

This is a deliberate, documented hold — not a permanent blind. Remove it once `typescript-eslint` and the tsup/DTS toolchain support TS7.

Config-only change, scoped to `.github/dependabot.yml`. No application code or tests affected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/itglue-mcp/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->