### PR TITLE
fix(search): real password tool coverage + flag silently-widened searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,25 @@
 
 ### Fixed
 
+- **The password tools had no effective test coverage — the suite was green
+  because the "tests" tested their own mock.** The five cases under
+  `describe("search_passwords")` / `describe("get_password")` in
+  `src/__tests__/index.test.ts` mocked `fetch`, then called `fetch` *directly*
+  and asserted on the payload the mock had just been handed. The
+  `search_passwords` / `get_password` handlers were never executed, so nothing
+  about the real request — the URL, the JSON:API filter keys, the
+  `show_password` flag, error propagation — was covered, and a regression in
+  either handler could ship with a fully green suite. The tell: the handler
+  names appeared only as `describe()` strings, never as a call. Replaced with a
+  `Password tools (round-trip)` block that drives the REAL server over an
+  `InMemoryTransport` pair (the idiom already used by the locations and
+  document-folder suites), covering: organization scoping and the forced
+  `show_password=false` on list calls, name/username/category filter
+  pass-through, `show_password` defaulting to true on `get_password` and
+  honouring an explicit `false`, the missing-`id` guard, and an IT Glue 404
+  surfacing as an error rather than an empty result. Net +2 tests (7 real
+  replacing 5 hollow) and, for the first time, real coverage of the handlers.
+
 - **`search_documents` no longer inlines document bodies, which made foldered
   organizations hang.** ([#55](https://github.com/wyre-technology/itglue-mcp/issues/55))
   IT Glue's documents LIST endpoint embeds each document's full sectioned body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,36 @@
 
 ### Fixed
 
+- **`search_passwords` could hand back plaintext secrets.** The handler asks IT
+  Glue not to send them (`show_password=false`), but that is a request, not a
+  guarantee: it sits one refactor away from being dropped, and a tenant or API
+  version that ignores the flag would spill every matched secret into the
+  model's context in a single bulk listing — the blast radius of a list call,
+  not a lookup. The test that claimed to cover this ("never returns a password
+  value even if the API sends one") used a fixture containing no password, so it
+  passed against a handler that had no redaction whatsoever. `search_passwords`
+  now strips the value on the way out via `stripPasswordValues()`, regardless of
+  what came back; `get_password` — the deliberate, one-id-at-a-time read path —
+  still returns it, and a test now pins that asymmetry.
+
+- **The account-wide-search warning disappeared exactly when it was needed.**
+  The organization filter is applied under `if (orgId)` while the warning added
+  in the previous release was gated on `orgId === undefined`. A falsy-but-present
+  id fell straight through the gap — `organization_id: 0`, or the `NaN` produced
+  by `Number(<non-numeric id>)` after an elicited organization lookup — dropping
+  the scope *and* suppressing the warning, which is precisely the silent
+  account-wide search the warning exists to prevent. Both now derive from the
+  filter that actually went out, through a single `unscopedSearchNoteFor()`
+  helper, so the two can no longer drift apart. Regression tests cover the
+  falsy-id case for all three search tools.
+
+- **The same warning misattributed its own cause.** It stated the client "could
+  not be asked" for an organization even when the user *had* been asked, *had*
+  answered, and the org-name lookup had simply matched nothing — pointing the
+  reader at a gateway elicitation problem that wasn't there. The handler cannot
+  distinguish "could not ask" from "asked, and nothing matched", so the note now
+  says what happened without guessing why.
+
 - **A scoped search silently became an account-wide one whenever the client
   couldn't be asked for an organization.** `search_passwords`,
   `search_configurations` and `search_locations` try to narrow themselves by
@@ -164,8 +194,42 @@
   `show_password=false` on list calls, name/username/category filter
   pass-through, `show_password` defaulting to true on `get_password` and
   honouring an explicit `false`, the missing-`id` guard, and an IT Glue 404
-  surfacing as an error rather than an empty result. Net +2 tests (7 real
-  replacing 5 hollow) and, for the first time, real coverage of the handlers.
+  surfacing as an error rather than an empty result. Eleven real tests replaced
+  five hollow ones and, for the first time, gave the handlers real coverage.
+
+- **The same hollowness ran through the rest of the suite: 14 of 25 tools had
+  no test that executed them.** The pattern was uniform — mock global `fetch`,
+  then call `fetch` *directly* and assert on the payload the mock had just been
+  handed, so the handler never ran and the test could not fail. The purest case
+  was `describe("Request Headers")`, which built a headers object, passed it to
+  `fetch`, and asserted the mock had captured those same values; it never
+  touched `ITGlueClient.authHeaders()`. Measured before this change: 25 tools
+  defined, 11 with a real `client.callTool` round-trip test, 14 with none, and
+  27 hollow tests. All 25 tools now have real round-trip coverage through the
+  in-memory transport idiom, and every conversion was mutation-checked —
+  deliberately breaking each handler makes its new test fail. New
+  `Core tools (round-trip)` covers the organization, configuration,
+  flexible-asset and health-check tools; new
+  `Document section tools (round-trip)` covers the section CRUD,
+  `publish_document` and archive/unarchive. `Unknown Tool Handling` asserted
+  `knownTools.length === 9` against a list literal the test itself wrote while
+  the server registered 25, and now drives the server instead, checking that
+  every advertised tool reaches a real branch rather than the unknown-tool
+  default. Tests that were purely circular were deleted outright rather than
+  rewritten: a test that cannot fail is worse than no test, because it buys
+  false confidence.
+
+- **One hollow test asserted the opposite of the shipped behaviour, and nothing
+  caught it.** "should include resource relationship in document section
+  payload" expected `create_document_section` to send a
+  `relationships.resource` binding. The handler deliberately does not: IT Glue
+  stores the section kind in the `resource_type` *attribute*, and a
+  relationships binding is rejected with a 400 for a missing `resource_type`
+  (verified live 2026-04-23, per the handler's own comment). Because the test
+  only ever inspected a payload it had constructed itself, the contradiction
+  between the test's claim and the code's behaviour sat there undetected. It is
+  replaced by a test that pins the real payload — `resource_type` present, no
+  relationships member — for both the `heading` and `text` mappings.
 
 - **`search_documents` no longer inlines document bodies, which made foldered
   organizations hang.** ([#55](https://github.com/wyre-technology/itglue-mcp/issues/55))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,29 @@
 
 ### Fixed
 
+- **A scoped search silently became an account-wide one whenever the client
+  couldn't be asked for an organization.** `search_passwords`,
+  `search_configurations` and `search_locations` try to narrow themselves by
+  eliciting an organization name when `organization_id` is omitted. Every
+  helper in `src/utils/elicitation.ts` ends in a bare `catch {}` returning
+  `null`, which collapses four distinct outcomes — no server bound, client
+  doesn't support elicitation, user declined, user answered — into one. On any
+  client without elicitation support, and through the MCP gateway (which does
+  not proxy server-initiated requests at all), the prompt is never delivered,
+  the handler drops the organization filter, and the query widens to the whole
+  account. A caller asking for "the VPN password for Acme" got an arbitrary
+  page drawn from every organization and reasonably reported that the entry did
+  not exist — indistinguishable, from the outside, from the entry genuinely
+  being absent. The query still runs (`organization_id` is legitimately
+  optional, and an account-wide search is a real use case), but an unscoped
+  result now carries `unscopedSearchNote()`: it states that ALL organizations
+  were searched, gives the page/total counts so a 50-of-4,000 slice can't be
+  mistaken for the whole picture, says explicitly that an empty result is not
+  proof of absence, and points at `search_organizations` +
+  `organization_id` to narrow it. Separately, the swallowed failure is now
+  logged to stderr with its reason, so a dropped prompt leaves a trace instead
+  of being undiagnosable — it was previously invisible at every layer.
+
 - **The password tools had no effective test coverage — the suite was green
   because the "tests" tested their own mock.** The five cases under
   `describe("search_passwords")` / `describe("get_password")` in

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -691,101 +691,6 @@ describe("Tool Handler Integration", () => {
     });
   });
 
-  describe("search_passwords", () => {
-    it("should search passwords without showing password values", async () => {
-      const mockData = createJsonApiResponse([
-        {
-          id: "1",
-          type: "passwords",
-          attributes: {
-            name: "Admin Password",
-            username: "admin",
-            url: "https://example.com",
-            // password field should not be included in search
-          },
-        },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/passwords?show_password=false");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Admin Password");
-      expect((json.data as JsonApiResource[])[0].attributes?.password).toBeUndefined();
-    });
-
-    it("should filter passwords by category", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1", type: "passwords", attributes: { name: "Database Password" } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/passwords?filter[password-category-id]=5");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[]).length).toBe(1);
-    });
-
-    it("should filter passwords by username", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1", type: "passwords", attributes: { name: "Admin Password", username: "admin" } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/passwords?filter[username]=admin");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[])[0].attributes?.username).toBe("admin");
-    });
-  });
-
-  describe("get_password", () => {
-    it("should get a password with show_password=true by default", async () => {
-      const mockData: JsonApiResponse = {
-        data: {
-          id: "55555",
-          type: "passwords",
-          attributes: {
-            name: "Server Root Password",
-            username: "root",
-            password: "secret123",
-          },
-        },
-      };
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/passwords/55555?show_password=true");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource).attributes?.password).toBe("secret123");
-    });
-
-    it("should respect show_password=false option", async () => {
-      const mockData: JsonApiResponse = {
-        data: {
-          id: "55555",
-          type: "passwords",
-          attributes: {
-            name: "Server Root Password",
-            username: "root",
-            // No password field
-          },
-        },
-      };
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/passwords/55555?show_password=false");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource).attributes?.password).toBeUndefined();
-    });
-  });
-
   describe("search_documents", () => {
     it("should search documents by organization", async () => {
       const mockData = createJsonApiResponse([
@@ -2326,6 +2231,179 @@ describe("Locations tools (round-trip)", () => {
     });
     expect(isError(result)).toBe(true);
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// Exercises the REAL password handlers (CallTool) over an in-memory transport
+// pair. The previous "password" tests in this file mocked fetch and then called
+// fetch directly, asserting on the mock's own payload — the search_passwords /
+// get_password handlers were never executed, so the whole surface was
+// effectively untested. fetch stays mocked underneath.
+describe("Password tools (round-trip)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function connectPasswordClient(): Promise<Client> {
+    const server = createMcpServer({ apiKey: "test-api-key" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "passwords-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  function firstText(result: unknown): string {
+    const r = result as { content?: Array<{ text?: string }> };
+    return r.content?.[0]?.text ?? "";
+  }
+
+  function isError(result: unknown): boolean {
+    return (result as { isError?: boolean }).isError === true;
+  }
+
+  it("search_passwords scopes to the organization and forces show_password=false", async () => {
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(
+        createJsonApiResponse([
+          {
+            id: "1",
+            type: "passwords",
+            attributes: { name: "VPN Admin", username: "admin" },
+          },
+        ])
+      )
+    );
+
+    const result = await client.callTool({
+      name: "search_passwords",
+      arguments: { organization_id: 8637099 },
+    });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).toContain("/passwords?");
+    expect(url).toContain("filter[organization-id]=8637099");
+    // Security: a list call must never ask IT Glue for secret material.
+    expect(url).toContain("show_password=false");
+    expect(firstText(result)).toContain("VPN Admin");
+  });
+
+  it("search_passwords never returns a password value even if the API sends one", async () => {
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(
+        createJsonApiResponse([
+          {
+            id: "1",
+            type: "passwords",
+            attributes: { name: "VPN Admin", username: "admin" },
+          },
+        ])
+      )
+    );
+
+    const result = await client.callTool({
+      name: "search_passwords",
+      arguments: { organization_id: 8637099 },
+    });
+
+    expect(firstText(result)).not.toContain("hunter2");
+  });
+
+  it("search_passwords passes name, username and category filters through", async () => {
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(createJsonApiResponse([]))
+    );
+
+    await client.callTool({
+      name: "search_passwords",
+      arguments: {
+        organization_id: 8637099,
+        name: "VPN",
+        username: "admin",
+        password_category_id: 5,
+      },
+    });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).toContain("filter[name]=VPN");
+    expect(url).toContain("filter[username]=admin");
+    expect(url).toContain("filter[password-category-id]=5");
+  });
+
+  it("get_password requests the secret value by default", async () => {
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        data: {
+          id: "55555",
+          type: "passwords",
+          attributes: { name: "Server Root", username: "root", password: "hunter2" },
+        },
+      })
+    );
+
+    const result = await client.callTool({
+      name: "get_password",
+      arguments: { id: "55555" },
+    });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).toContain("/passwords/55555");
+    expect(url).toContain("show_password=true");
+    expect(firstText(result)).toContain("hunter2");
+  });
+
+  it("get_password honours show_password=false", async () => {
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        data: {
+          id: "55555",
+          type: "passwords",
+          attributes: { name: "Server Root", username: "root" },
+        },
+      })
+    );
+
+    await client.callTool({
+      name: "get_password",
+      arguments: { id: "55555", show_password: false },
+    });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).toContain("show_password=false");
+  });
+
+  it("get_password returns an error when id is missing", async () => {
+    const client = await connectPasswordClient();
+    const result = await client.callTool({
+      name: "get_password",
+      arguments: {},
+    });
+    expect(isError(result)).toBe(true);
+    expect(firstText(result).toLowerCase()).toContain("id is required");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an IT Glue 404 rather than reporting an empty result", async () => {
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: async () => '{"errors":[{"status":404,"title":"Not Found"}]}',
+    } as Response);
+
+    const result = await client.callTool({
+      name: "get_password",
+      arguments: { id: "does-not-exist" },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(firstText(result)).toContain("404");
   });
 });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2389,6 +2389,47 @@ describe("Password tools (round-trip)", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("flags an account-wide search when no organization_id was given and the client cannot be asked", async () => {
+    // Through a gateway that does not proxy elicitation, elicitText() returns
+    // null and the handler silently drops org scoping — a caller asking for
+    // "the VPN password for Acme" gets an arbitrary slice of every org's
+    // passwords and concludes the entry does not exist. The result must say so.
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(
+        createJsonApiResponse([
+          { id: "1", type: "passwords", attributes: { name: "VPN Admin" } },
+        ])
+      )
+    );
+
+    const result = await client.callTool({
+      name: "search_passwords",
+      arguments: { name: "VPN" },
+    });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).not.toContain("filter[organization-id]");
+    const text = firstText(result);
+    expect(text).toContain("ALL organizations");
+    // and must not let the caller read an unscoped miss as "does not exist"
+    expect(text.toLowerCase()).toContain("organization_id");
+  });
+
+  it("does not flag an organization-scoped search", async () => {
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(createJsonApiResponse([]))
+    );
+
+    const result = await client.callTool({
+      name: "search_passwords",
+      arguments: { organization_id: 8637099 },
+    });
+
+    expect(firstText(result)).not.toContain("ALL organizations");
+  });
+
   it("surfaces an IT Glue 404 rather than reporting an empty result", async () => {
     const client = await connectPasswordClient();
     mockFetch.mockResolvedValueOnce({

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -34,6 +34,7 @@ import {
   requestDocumentsWithFolderDefault,
   rootLevelDocumentsNote,
   stripDocumentBodies,
+  stripPasswordValues,
 } from "../index.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -274,42 +275,40 @@ describe("ITGlueClient", () => {
   });
 
   describe("Request Headers", () => {
-    it("should include correct headers in request", async () => {
-      let capturedHeaders: Record<string, string> = {};
+    // Asserts on what ITGlueClient.authHeaders() actually put on the wire.
+    // The previous version of this test hand-built a headers object, handed it
+    // to the fetch mock itself, and asserted the mock had received it — it
+    // never touched the client and could not fail.
+    it("sends the API key and the JSON:API content negotiation headers", async () => {
+      mockFetch.mockImplementation(() =>
+        createMockResponse(createJsonApiResponse([]))
+      );
 
-      mockFetch.mockImplementation((_url: string, options: RequestInit) => {
-        capturedHeaders = options.headers as Record<string, string>;
-        return createMockResponse(createJsonApiResponse([]));
-      });
+      const client = new ITGlueClient({ apiKey: "test-api-key", region: "us" });
+      await client.request("/organizations");
 
-      // Simulate the header setup
-      const headers = {
-        "x-api-key": "test-api-key",
-        "Content-Type": "application/vnd.api+json",
-        Accept: "application/vnd.api+json",
-      };
-
-      await fetch("https://api.itglue.com/organizations", {
-        method: "GET",
-        headers,
-      });
-
-      expect(capturedHeaders["x-api-key"]).toBe("test-api-key");
-      expect(capturedHeaders["Content-Type"]).toBe("application/vnd.api+json");
-      expect(capturedHeaders["Accept"]).toBe("application/vnd.api+json");
+      const headers = (mockFetch.mock.calls[0][1] as RequestInit)
+        .headers as Record<string, string>;
+      expect(headers["x-api-key"]).toBe("test-api-key");
+      expect(headers["Content-Type"]).toBe("application/vnd.api+json");
+      expect(headers["Accept"]).toBe("application/vnd.api+json");
     });
   });
 
   describe("Error Handling", () => {
-    it("should handle non-OK HTTP responses", async () => {
+    it("turns a non-OK HTTP response into a thrown error carrying the status", async () => {
       mockFetch.mockResolvedValueOnce(createErrorResponse(401, "Unauthorized"));
 
-      const response = await fetch("https://api.itglue.com/organizations");
-      expect(response.ok).toBe(false);
-      expect(response.status).toBe(401);
+      const client = new ITGlueClient({ apiKey: "test-api-key", region: "us" });
+      await expect(client.request("/organizations")).rejects.toThrow(
+        /IT Glue API error \(401\).*Unauthorized/
+      );
     });
 
-    it("should handle JSON:API error responses", async () => {
+    it("throws on a 200 response that carries a JSON:API errors array", async () => {
+      // IT Glue can answer 200 OK with an `errors` member; treating that as a
+      // successful empty result would report "no such organization" for what is
+      // really a server-side failure.
       const errorBody: JsonApiResponse = {
         data: [],
         errors: [
@@ -318,16 +317,19 @@ describe("ITGlueClient", () => {
       };
       mockFetch.mockResolvedValueOnce(createMockResponse(errorBody));
 
-      const response = await fetch("https://api.itglue.com/organizations/999999");
-      const json = (await response.json()) as JsonApiResponse;
-      expect(json.errors).toBeDefined();
-      expect(json.errors![0].detail).toBe("Organization not found");
+      const client = new ITGlueClient({ apiKey: "test-api-key", region: "us" });
+      await expect(client.request("/organizations/999999")).rejects.toThrow(
+        "IT Glue API error: Organization not found"
+      );
     });
 
-    it("should handle network errors", async () => {
+    it("propagates transport-level failures unchanged", async () => {
       mockFetch.mockRejectedValueOnce(new Error("Network error"));
 
-      await expect(fetch("https://api.itglue.com/organizations")).rejects.toThrow("Network error");
+      const client = new ITGlueClient({ apiKey: "test-api-key", region: "us" });
+      await expect(client.request("/organizations")).rejects.toThrow(
+        "Network error"
+      );
     });
   });
 });
@@ -509,217 +511,12 @@ describe("Tool Handler Integration", () => {
     process.env = originalEnv;
   });
 
-  describe("search_organizations", () => {
-    it("should search organizations without filters", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1", type: "organizations", attributes: { name: "Acme Corp", "short-name": "ACME" } },
-        { id: "2", type: "organizations", attributes: { name: "Beta Inc", "short-name": "BETA" } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/organizations?page[size]=50&page[number]=1");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect(Array.isArray(json.data)).toBe(true);
-      expect((json.data as JsonApiResource[]).length).toBe(2);
-      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Acme Corp");
-    });
-
-    it("should search organizations with name filter", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1", type: "organizations", attributes: { name: "Acme Corp" } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/organizations?filter[name]=Acme");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[]).length).toBe(1);
-      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Acme Corp");
-    });
-
-    it("should search organizations with pagination", async () => {
-      const mockData = createJsonApiResponse(
-        [{ id: "1", type: "organizations", attributes: { name: "Test" } }],
-        {
-          "current-page": 2,
-          "next-page": 3,
-          "prev-page": 1,
-          "total-pages": 5,
-          "total-count": 100,
-        }
-      );
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/organizations?page[number]=2");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect(json.meta?.["current-page"]).toBe(2);
-      expect(json.meta?.["total-count"]).toBe(100);
-    });
-
-    it("should search organizations with sort", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "2", type: "organizations", attributes: { name: "Beta Inc" } },
-        { id: "1", type: "organizations", attributes: { name: "Acme Corp" } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/organizations?sort=-name");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Beta Inc");
-    });
-  });
-
-  describe("get_organization", () => {
-    it("should get a single organization by ID", async () => {
-      const mockData: JsonApiResponse = {
-        data: {
-          id: "12345",
-          type: "organizations",
-          attributes: {
-            name: "Acme Corp",
-            "short-name": "ACME",
-            description: "A test organization",
-            "created-at": "2024-01-01T00:00:00Z",
-            "updated-at": "2024-01-02T00:00:00Z",
-          },
-        },
-      };
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/organizations/12345");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource).id).toBe("12345");
-      expect((json.data as JsonApiResource).attributes?.name).toBe("Acme Corp");
-    });
-
-    it("should return error when ID is missing", () => {
-      const args: Record<string, string> = {};
-      const hasId = "id" in args && args.id;
-
-      expect(hasId).toBeFalsy();
-    });
-
-    it("should handle organization not found", async () => {
-      mockFetch.mockResolvedValueOnce(createErrorResponse(404, "Not Found"));
-
-      const response = await fetch("https://api.itglue.com/organizations/999999");
-      expect(response.ok).toBe(false);
-      expect(response.status).toBe(404);
-    });
-  });
-
-  describe("search_configurations", () => {
-    it("should search configurations with organization filter", async () => {
-      const mockData = createJsonApiResponse([
-        {
-          id: "1",
-          type: "configurations",
-          attributes: {
-            name: "Server-01",
-            "configuration-type-name": "Server",
-            "serial-number": "SN12345",
-          },
-        },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/configurations?filter[organization-id]=123");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Server-01");
-      expect((json.data as JsonApiResource[])[0].attributes?.["serial-number"]).toBe("SN12345");
-    });
-
-    it("should search configurations with multiple filters", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1", type: "configurations", attributes: { name: "Laptop-01" } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/configurations?filter[organization-id]=1&filter[configuration-type-id]=5");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[]).length).toBe(1);
-    });
-
-    it("should search configurations by serial number", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1", type: "configurations", attributes: { name: "Server-01", "serial-number": "ABC123" } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/configurations?filter[serial-number]=ABC123");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[])[0].attributes?.["serial-number"]).toBe("ABC123");
-    });
-  });
-
-  describe("get_configuration", () => {
-    it("should get a single configuration by ID", async () => {
-      const mockData: JsonApiResponse = {
-        data: {
-          id: "99999",
-          type: "configurations",
-          attributes: {
-            name: "Desktop-05",
-            "ip-address": "192.168.1.100",
-            "mac-address": "00:11:22:33:44:55",
-          },
-        },
-      };
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/configurations/99999");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource).id).toBe("99999");
-      expect((json.data as JsonApiResource).attributes?.["ip-address"]).toBe("192.168.1.100");
-    });
-  });
-
-  describe("search_documents", () => {
-    it("should search documents by organization", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1", type: "documents", attributes: { name: "Network Diagram", content: "..." } },
-        { id: "2", type: "documents", attributes: { name: "Setup Guide", content: "..." } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/organizations/123/relationships/documents?page[size]=50&page[number]=1");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[]).length).toBe(2);
-      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Network Diagram");
-    });
-
-    it("should search documents by name within organization", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1", type: "documents", attributes: { name: "Security Policy" } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/organizations/123/relationships/documents?filter[name]=Security&page[size]=50&page[number]=1");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Security Policy");
-    });
-  });
+  // search_organizations, get_organization, search_configurations,
+  // get_configuration and search_documents used to be "tested" here by calling
+  // the fetch mock directly and asserting on the payload the mock had just been
+  // handed — the handlers never ran. Real round-trip coverage now lives in
+  // "Core tools (round-trip)" below (and, for search_documents, in
+  // "Document folder access (API-key-first, round-trip)").
 
   // Regression tests for wyre-technology/msp-claude-plugins#134: an org-wide
   // search_documents returns only ROOT-LEVEL documents (IT Glue API limitation),
@@ -780,6 +577,22 @@ describe("Tool Handler Integration", () => {
     it("leaves documents without a content field untouched", () => {
       const docs = [{ id: "2", name: "Root Doc", documentFolderId: null }];
       expect(stripDocumentBodies(docs)).toEqual(docs);
+    });
+  });
+
+  describe("stripPasswordValues", () => {
+    it("removes the secret while preserving every other field", () => {
+      const stripped = stripPasswordValues([
+        { id: "1", name: "VPN Admin", username: "admin", password: "hunter2" },
+      ]);
+      expect(stripped).toEqual([
+        { id: "1", name: "VPN Admin", username: "admin" },
+      ]);
+    });
+
+    it("leaves records without a password field untouched", () => {
+      const pws = [{ id: "2", name: "No Secret", username: "svc" }];
+      expect(stripPasswordValues(pws)).toEqual(pws);
     });
   });
 
@@ -1257,316 +1070,56 @@ describe("Tool Handler Integration", () => {
     });
   });
 
-  describe("list_document_sections", () => {
-    it("should list sections for a document", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1001", type: "document-sections", attributes: { content: "<h2>Overview</h2>", "section-type": "Document::Heading", position: 1 } },
-        { id: "1002", type: "document-sections", attributes: { content: "<p>Details here.</p>", "section-type": "Document::Text", position: 2 } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/documents/789/relationships/sections");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[]).length).toBe(2);
-      expect((json.data as JsonApiResource[])[0].attributes?.["section-type"]).toBe("Document::Heading");
-    });
-  });
-
-  describe("create_document_section", () => {
-    it("should map 'heading' type to Document::Heading", () => {
-      const sectionTypeMap: Record<string, string> = { heading: "Document::Heading", text: "Document::Text" };
-      expect(sectionTypeMap["heading"]).toBe("Document::Heading");
-    });
-
-    it("should map 'text' type to Document::Text", () => {
-      const sectionTypeMap: Record<string, string> = { heading: "Document::Heading", text: "Document::Text" };
-      expect(sectionTypeMap["text"]).toBe("Document::Text");
-    });
-
-    it("should post a new section to the sections endpoint", async () => {
-      const mockSection = { id: "1003", type: "document-sections", attributes: { content: "<p>New section.</p>", "section-type": "Document::Text" } };
-      mockFetch.mockResolvedValueOnce(createMockResponse({ data: mockSection, meta: {} }));
-
-      const response = await fetch("https://api.itglue.com/documents/789/relationships/sections", {
-        method: "POST",
-        headers: { "Content-Type": "application/vnd.api+json" },
-        body: JSON.stringify({ data: { type: "document-sections", attributes: { "section-type": "Document::Text", content: "<p>New section.</p>" } } }),
-      });
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.itglue.com/documents/789/relationships/sections",
-        expect.objectContaining({ method: "POST" })
-      );
-      expect(response.ok).toBe(true);
-    });
-
-    // BUG TEST #2: This test demonstrates that create_document_section should include resource relationship
-    it("should include resource relationship in document section payload", async () => {
-      let capturedBody: string = "";
-
-      const mockSection = { id: "1003", type: "document-sections", attributes: { content: "<p>New section.</p>", "section-type": "Document::Text" } };
-      mockFetch.mockImplementation((_url: string, options: RequestInit) => {
-        capturedBody = options.body as string;
-        return createMockResponse({ data: mockSection, meta: {} });
-      });
-
-      // This should now POST with the correct payload that includes resource relationship
-      await fetch("https://api.itglue.com/documents/789/relationships/sections", {
-        method: "POST",
-        headers: { "Content-Type": "application/vnd.api+json" },
-        body: JSON.stringify({
-          data: {
-            type: "document-sections",
-            attributes: {
-              "section-type": "Document::Text",
-              content: "<p>New section.</p>"
-            },
-            relationships: {
-              resource: {
-                data: {
-                  type: "documents",
-                  id: "789"
-                }
-              }
-            }
-          }
-        }),
-      });
-
-      const parsedBody = JSON.parse(capturedBody);
-
-      // Verify basic structure
-      expect(parsedBody.data.type).toBe("document-sections");
-      expect(parsedBody.data.attributes["section-type"]).toBe("Document::Text");
-      expect(parsedBody.data.attributes.content).toBe("<p>New section.</p>");
-
-      // Verify the fix - should include relationships.resource binding (Option B)
-      expect(parsedBody.data.relationships?.resource?.data?.type).toBe("documents");
-      expect(parsedBody.data.relationships?.resource?.data?.id).toBe("789");
-    });
-
-    it("should fail with 400 error when resource relationship is missing", async () => {
-      // Mock the actual 400 error from IT Glue API
-      const errorResponse = {
-        errors: [{
-          title: "Bad Request",
-          detail: "param is missing or the value is empty: resource_type",
-          status: "400"
-        }]
-      };
-      mockFetch.mockResolvedValueOnce(createErrorResponse(400, JSON.stringify(errorResponse)));
-
-      const response = await fetch("https://api.itglue.com/documents/789/relationships/sections", {
-        method: "POST",
-        headers: { "Content-Type": "application/vnd.api+json" },
-        body: JSON.stringify({
-          data: {
-            type: "document-sections",
-            attributes: {
-              "section-type": "Document::Text",
-              content: "<p>New section.</p>"
-            }
-          }
-        }),
-      });
-
-      expect(response.ok).toBe(false);
-      expect(response.status).toBe(400);
-
-      const errorText = await response.text();
-      expect(errorText).toContain("resource_type");
-    });
-  });
-
-  describe("update_document_section", () => {
-    it("should patch the section with new content", async () => {
-      const mockSection = { id: "1002", type: "document-sections", attributes: { content: "<p>Updated.</p>" } };
-      mockFetch.mockResolvedValueOnce(createMockResponse({ data: mockSection, meta: {} }));
-
-      const response = await fetch("https://api.itglue.com/documents/789/relationships/sections/1002", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/vnd.api+json" },
-        body: JSON.stringify({ data: { type: "document-sections", attributes: { content: "<p>Updated.</p>" } } }),
-      });
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.itglue.com/documents/789/relationships/sections/1002",
-        expect.objectContaining({ method: "PATCH" })
-      );
-      expect(response.ok).toBe(true);
-    });
-  });
-
-  describe("delete_document_section", () => {
-    it("should delete a section", async () => {
-      mockFetch.mockResolvedValueOnce(createMockResponse(null, 204));
-
-      const response = await fetch("https://api.itglue.com/documents/789/relationships/sections/1002", {
-        method: "DELETE",
-      });
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.itglue.com/documents/789/relationships/sections/1002",
-        expect.objectContaining({ method: "DELETE" })
-      );
-      expect(response.status).toBe(204);
-    });
-  });
-
-  describe("publish_document", () => {
-    it("should use PATCH method (not POST)", async () => {
-      const mockDoc = { id: "789", type: "documents", attributes: { name: "My Doc" } };
-      mockFetch.mockResolvedValueOnce(createMockResponse({ data: mockDoc, meta: {} }));
-
-      const response = await fetch("https://api.itglue.com/documents/789/publish", {
-        method: "PATCH",
-      });
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.itglue.com/documents/789/publish",
-        expect.objectContaining({ method: "PATCH" })
-      );
-      expect(response.ok).toBe(true);
-    });
-  });
-
-  describe("archive_document / unarchive_document", () => {
-    // Pins the URL, method, and payload shape so a future refactor can't
-    // silently omit `archived` or swap to a non-existent /archive sub-endpoint.
-    it.each([true, false])("PATCH /documents/:id with archived=%s", async (archived) => {
-      mockFetch.mockResolvedValueOnce(createMockResponse({ data: {}, meta: {} }));
-
-      await fetch("https://api.itglue.com/documents/789", {
-        method: "PATCH",
-        body: JSON.stringify({
-          data: { type: "documents", attributes: { archived } },
-        }),
-      });
-
-      const [, init] = mockFetch.mock.calls[0];
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.itglue.com/documents/789",
-        expect.objectContaining({ method: "PATCH" })
-      );
-      expect(JSON.parse(init.body as string)).toEqual({
-        data: { type: "documents", attributes: { archived } },
-      });
-    });
-  });
-
-  describe("search_flexible_assets", () => {
-    it("should require flexible_asset_type_id", () => {
-      const args: Record<string, number> = { organization_id: 1 };
-      const hasRequiredField = "flexible_asset_type_id" in args;
-
-      expect(hasRequiredField).toBe(false);
-    });
-
-    it("should search flexible assets with type ID", async () => {
-      const mockData = createJsonApiResponse([
-        {
-          id: "1",
-          type: "flexible-assets",
-          attributes: { name: "Network Asset", traits: { "ip-address": "10.0.0.1" } },
-        },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/flexible_assets?filter[flexible-asset-type-id]=5");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[])[0].type).toBe("flexible-assets");
-      expect((json.data as JsonApiResource[])[0].attributes?.name).toBe("Network Asset");
-    });
-
-    it("should filter flexible assets by organization", async () => {
-      const mockData = createJsonApiResponse([
-        { id: "1", type: "flexible-assets", attributes: { name: "Asset 1" } },
-      ]);
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/flexible_assets?filter[flexible-asset-type-id]=5&filter[organization-id]=123");
-      const json = (await response.json()) as JsonApiResponse;
-
-      expect((json.data as JsonApiResource[]).length).toBe(1);
-    });
-  });
-
-  describe("itglue_health_check", () => {
-    it("should return success status when API is reachable", async () => {
-      const mockData = createJsonApiResponse(
-        [{ id: "1", type: "organization-types", attributes: { name: "Customer" } }],
-        { "total-count": 5 }
-      );
-
-      mockFetch.mockResolvedValueOnce(createMockResponse(mockData));
-
-      const response = await fetch("https://api.itglue.com/organization_types?page[size]=1");
-      const json = (await response.json()) as JsonApiResponse;
-
-      const healthResponse = {
-        status: "ok",
-        message: "IT Glue API is reachable",
-        region: "us",
-        organizationTypesFound: json.meta?.["total-count"],
-      };
-
-      expect(healthResponse.status).toBe("ok");
-      expect(healthResponse.organizationTypesFound).toBe(5);
-    });
-
-    it("should return error when API is unreachable", async () => {
-      mockFetch.mockRejectedValueOnce(new Error("Network error"));
-
-      await expect(fetch("https://api.itglue.com/organization_types")).rejects.toThrow("Network error");
-    });
-
-    it("should return error for authentication failure", async () => {
-      mockFetch.mockResolvedValueOnce(createErrorResponse(401, "Invalid API Key"));
-
-      const response = await fetch("https://api.itglue.com/organization_types");
-      expect(response.ok).toBe(false);
-      expect(response.status).toBe(401);
-    });
-  });
+  // The document-section, publish/archive, flexible-asset and health-check
+  // tools were also only ever exercised against the fetch mock directly. Their
+  // real round-trip coverage lives in "Document section tools (round-trip)" and
+  // "Core tools (round-trip)" below.
 });
 
 describe("Unknown Tool Handling", () => {
-  it("should return error for unknown tool name", () => {
-    const unknownTool = "nonexistent_tool";
-    const knownTools = [
-      "search_organizations",
-      "get_organization",
-      "search_configurations",
-      "get_configuration",
-      "search_passwords",
-      "get_password",
-      "search_documents",
-      "search_flexible_assets",
-      "itglue_health_check",
-    ];
-
-    expect(knownTools.includes(unknownTool)).toBe(false);
+  // Previously this asserted `knownTools.length === 9` against a list literal
+  // the test itself wrote — while the server registered 25 tools. It tracked
+  // the test's own copy of reality, not the server's.
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it("should list all known tools", () => {
-    const knownTools = [
-      "search_organizations",
-      "get_organization",
-      "search_configurations",
-      "get_configuration",
-      "search_passwords",
-      "get_password",
-      "search_documents",
-      "search_flexible_assets",
-      "itglue_health_check",
-    ];
+  async function connectClient(): Promise<Client> {
+    const server = createMcpServer({ apiKey: "test-api-key" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "unknown-tool-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    return client;
+  }
 
-    expect(knownTools.length).toBe(9);
+  it("returns an error result for a tool the server does not implement", async () => {
+    const client = await connectClient();
+    const result = (await client.callTool({
+      name: "nonexistent_tool",
+      arguments: {},
+    })) as { isError?: boolean; content?: Array<{ text?: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain("Unknown tool: nonexistent_tool");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("advertises exactly the tools it can dispatch", async () => {
+    const client = await connectClient();
+    const { tools } = await client.listTools();
+
+    expect(tools.length).toBe(25);
+    // Every advertised tool must reach a real branch — not the Unknown-tool
+    // default — so a rename in the ListTools block can't drift from the switch.
+    for (const tool of tools) {
+      const result = (await client.callTool({
+        name: tool.name,
+        arguments: {},
+      })) as { content?: Array<{ text?: string }> };
+      expect(result.content?.[0]?.text ?? "").not.toContain("Unknown tool:");
+    }
   });
 });
 
@@ -2232,6 +1785,64 @@ describe("Locations tools (round-trip)", () => {
     expect(isError(result)).toBe(true);
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  // unscopedSearchNote() is wired into search_locations as well as
+  // search_passwords and search_configurations: when elicitation cannot reach
+  // the client the handler drops org scoping, and "the Chattanooga office for
+  // Acme" quietly becomes "every Chattanooga office in the account".
+  it("flags an account-wide search when no organization_id was given", async () => {
+    const client = await connectLocationsClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(
+        createJsonApiResponse([
+          { id: "5", type: "locations", attributes: { name: "Primary Address" } },
+        ])
+      )
+    );
+
+    const result = await client.callTool({
+      name: "search_locations",
+      arguments: { city: "Chattanooga" },
+    });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).not.toContain("filter[organization-id]");
+    const text = firstText(result);
+    expect(text).toContain("ALL organizations");
+    expect(text.toLowerCase()).toContain("organization_id");
+  });
+
+  it("does not flag an organization-scoped search", async () => {
+    const client = await connectLocationsClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(createJsonApiResponse([]))
+    );
+
+    const result = await client.callTool({
+      name: "search_locations",
+      arguments: { organization_id: 8637099 },
+    });
+
+    expect(firstText(result)).not.toContain("ALL organizations");
+  });
+
+  // See the equivalent search_configurations test: the warning must track the
+  // filter that was actually sent, not the raw argument.
+  it("flags the search when a falsy organization_id drops the filter", async () => {
+    const client = await connectLocationsClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(createJsonApiResponse([]))
+    );
+
+    const result = await client.callTool({
+      name: "search_locations",
+      arguments: { organization_id: 0 },
+    });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).not.toContain("filter[organization-id]");
+    expect(firstText(result)).toContain("ALL organizations");
+  });
 });
 
 // Exercises the REAL password handlers (CallTool) over an in-memory transport
@@ -2291,6 +1902,10 @@ describe("Password tools (round-trip)", () => {
   });
 
   it("search_passwords never returns a password value even if the API sends one", async () => {
+    // The fixture deliberately DOES carry a secret: show_password=false is a
+    // request to IT Glue, not a guarantee, so the list tool has to redact on the
+    // way out too. An earlier version of this test used a secret-free fixture
+    // and therefore passed against a handler that had no redaction at all.
     const client = await connectPasswordClient();
     mockFetch.mockResolvedValueOnce(
       createMockResponse(
@@ -2298,7 +1913,11 @@ describe("Password tools (round-trip)", () => {
           {
             id: "1",
             type: "passwords",
-            attributes: { name: "VPN Admin", username: "admin" },
+            attributes: {
+              name: "VPN Admin",
+              username: "admin",
+              password: "hunter2",
+            },
           },
         ])
       )
@@ -2309,7 +1928,31 @@ describe("Password tools (round-trip)", () => {
       arguments: { organization_id: 8637099 },
     });
 
-    expect(firstText(result)).not.toContain("hunter2");
+    const text = firstText(result);
+    expect(text).not.toContain("hunter2");
+    // the rest of the record still comes through
+    expect(text).toContain("VPN Admin");
+    expect(text).toContain("admin");
+  });
+
+  it("get_password still returns the secret — redaction is list-only", async () => {
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        data: {
+          id: "55555",
+          type: "passwords",
+          attributes: { name: "Server Root", password: "hunter2" },
+        },
+      })
+    );
+
+    const result = await client.callTool({
+      name: "get_password",
+      arguments: { id: "55555" },
+    });
+
+    expect(firstText(result)).toContain("hunter2");
   });
 
   it("search_passwords passes name, username and category filters through", async () => {
@@ -2430,6 +2073,24 @@ describe("Password tools (round-trip)", () => {
     expect(firstText(result)).not.toContain("ALL organizations");
   });
 
+  // See the equivalent search_configurations test: the warning must track the
+  // filter that was actually sent, not the raw argument.
+  it("flags the search when a falsy organization_id drops the filter", async () => {
+    const client = await connectPasswordClient();
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse(createJsonApiResponse([]))
+    );
+
+    const result = await client.callTool({
+      name: "search_passwords",
+      arguments: { organization_id: 0 },
+    });
+
+    const url = decodeURIComponent(mockFetch.mock.calls[0][0] as string);
+    expect(url).not.toContain("filter[organization-id]");
+    expect(firstText(result)).toContain("ALL organizations");
+  });
+
   it("surfaces an IT Glue 404 rather than reporting an empty result", async () => {
     const client = await connectPasswordClient();
     mockFetch.mockResolvedValueOnce({
@@ -2445,6 +2106,843 @@ describe("Password tools (round-trip)", () => {
 
     expect(isError(result)).toBe(true);
     expect(firstText(result)).toContain("404");
+  });
+});
+
+// Round-trip coverage for the organization, configuration, flexible-asset and
+// health-check tools. These handlers previously had no test that executed them
+// at all: the suite called the fetch mock directly and asserted on the payload
+// it had just supplied, so the tools could have been deleted outright and the
+// suite would still have been green.
+describe("Core tools (round-trip)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function connectCoreClient(): Promise<Client> {
+    const server = createMcpServer({ apiKey: "test-api-key" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "core-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  function firstText(result: unknown): string {
+    const r = result as { content?: Array<{ text?: string }> };
+    return r.content?.[0]?.text ?? "";
+  }
+
+  function isError(result: unknown): boolean {
+    return (result as { isError?: boolean }).isError === true;
+  }
+
+  function decodedUrl(callIndex = 0): string {
+    return decodeURIComponent(mockFetch.mock.calls[callIndex][0] as string);
+  }
+
+  describe("search_organizations", () => {
+    it("pages the unfiltered listing and returns the organizations", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            { id: "1", type: "organizations", attributes: { name: "Acme Corp" } },
+            { id: "2", type: "organizations", attributes: { name: "Beta Inc" } },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "search_organizations",
+        arguments: {},
+      });
+
+      const url = decodedUrl();
+      expect(url).toContain("/organizations?");
+      expect(url).toContain("page[size]=50");
+      expect(url).toContain("page[number]=1");
+      expect(firstText(result)).toContain("Acme Corp");
+    });
+
+    it("passes the name filter through as filter[name]", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(createJsonApiResponse([]))
+      );
+
+      await client.callTool({
+        name: "search_organizations",
+        arguments: { name: "Acme" },
+      });
+
+      expect(decodedUrl()).toContain("filter[name]=Acme");
+    });
+
+    it("kebab-cases the type/status filters and forwards sort and pagination", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(createJsonApiResponse([]))
+      );
+
+      await client.callTool({
+        name: "search_organizations",
+        arguments: {
+          organization_type_id: 7,
+          organization_status_id: 9,
+          sort: "-name",
+          page_size: 25,
+          page_number: 2,
+        },
+      });
+
+      const url = decodedUrl();
+      expect(url).toContain("filter[organization-type-id]=7");
+      expect(url).toContain("filter[organization-status-id]=9");
+      expect(url).toContain("sort=-name");
+      expect(url).toContain("page[size]=25");
+      expect(url).toContain("page[number]=2");
+    });
+
+    it("sends the API key and JSON:API headers on the handler's own request", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(createJsonApiResponse([]))
+      );
+
+      await client.callTool({
+        name: "search_organizations",
+        arguments: { name: "Acme" },
+      });
+
+      const headers = (mockFetch.mock.calls[0][1] as RequestInit)
+        .headers as Record<string, string>;
+      expect(headers["x-api-key"]).toBe("test-api-key");
+      expect(headers["Content-Type"]).toBe("application/vnd.api+json");
+      expect(headers["Accept"]).toBe("application/vnd.api+json");
+    });
+  });
+
+  describe("get_organization", () => {
+    it("fetches a single organization by id", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: "12345",
+            type: "organizations",
+            attributes: { name: "Acme Corp", "short-name": "ACME" },
+          },
+        })
+      );
+
+      const result = await client.callTool({
+        name: "get_organization",
+        arguments: { id: 12345 },
+      });
+
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://api.itglue.com/organizations/12345"
+      );
+      expect(firstText(result)).toContain("Acme Corp");
+    });
+
+    it("returns an error without calling the API when id is missing", async () => {
+      const client = await connectCoreClient();
+      const result = await client.callTool({
+        name: "get_organization",
+        arguments: {},
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("Organization ID is required");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("surfaces an IT Glue 404 as an error result", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(createErrorResponse(404, "Not Found"));
+
+      const result = await client.callTool({
+        name: "get_organization",
+        arguments: { id: 999999 },
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("404");
+    });
+  });
+
+  describe("search_configurations", () => {
+    it("scopes to the organization and returns the configurations", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            {
+              id: "1",
+              type: "configurations",
+              attributes: { name: "Server-01", "serial-number": "SN12345" },
+            },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "search_configurations",
+        arguments: { organization_id: 123 },
+      });
+
+      const url = decodedUrl();
+      expect(url).toContain("/configurations?");
+      expect(url).toContain("filter[organization-id]=123");
+      expect(firstText(result)).toContain("SN12345");
+    });
+
+    it("kebab-cases every configuration filter it accepts", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(createJsonApiResponse([]))
+      );
+
+      await client.callTool({
+        name: "search_configurations",
+        arguments: {
+          organization_id: 1,
+          name: "Laptop-01",
+          configuration_type_id: 5,
+          configuration_status_id: 6,
+          serial_number: "ABC123",
+          rmm_id: "rmm-1",
+          psa_id: "psa-1",
+        },
+      });
+
+      const url = decodedUrl();
+      expect(url).toContain("filter[organization-id]=1");
+      expect(url).toContain("filter[name]=Laptop-01");
+      expect(url).toContain("filter[configuration-type-id]=5");
+      expect(url).toContain("filter[configuration-status-id]=6");
+      expect(url).toContain("filter[serial-number]=ABC123");
+      expect(url).toContain("filter[rmm-id]=rmm-1");
+      expect(url).toContain("filter[psa-id]=psa-1");
+    });
+
+    // unscopedSearchNote() is wired into search_configurations as well as
+    // search_passwords: through a gateway that cannot proxy elicitation the
+    // handler silently drops org scoping, and a caller asking for "the switch
+    // at Acme" gets an arbitrary slice of every org's configurations.
+    it("flags an account-wide search when no organization_id was given", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            { id: "1", type: "configurations", attributes: { name: "Server-01" } },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "search_configurations",
+        arguments: { name: "Server" },
+      });
+
+      expect(decodedUrl()).not.toContain("filter[organization-id]");
+      const text = firstText(result);
+      expect(text).toContain("ALL organizations");
+      expect(text.toLowerCase()).toContain("organization_id");
+    });
+
+    it("does not flag an organization-scoped search", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(createJsonApiResponse([]))
+      );
+
+      const result = await client.callTool({
+        name: "search_configurations",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(firstText(result)).not.toContain("ALL organizations");
+    });
+
+    // The filter is applied under `if (orgId)` but the warning used to be gated
+    // on `orgId === undefined`. A falsy-but-present id fell through the gap:
+    // the org filter was dropped AND the warning suppressed — the exact silent
+    // account-wide search the note exists to prevent.
+    it("flags the search when a falsy organization_id drops the filter", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(createJsonApiResponse([]))
+      );
+
+      const result = await client.callTool({
+        name: "search_configurations",
+        arguments: { organization_id: 0 },
+      });
+
+      expect(decodedUrl()).not.toContain("filter[organization-id]");
+      expect(firstText(result)).toContain("ALL organizations");
+    });
+  });
+
+  describe("get_configuration", () => {
+    it("fetches a single configuration by id", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: "99999",
+            type: "configurations",
+            attributes: { name: "Desktop-05", "ip-address": "192.168.1.100" },
+          },
+        })
+      );
+
+      const result = await client.callTool({
+        name: "get_configuration",
+        arguments: { id: 99999 },
+      });
+
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://api.itglue.com/configurations/99999"
+      );
+      expect(firstText(result)).toContain("192.168.1.100");
+    });
+
+    it("returns an error without calling the API when id is missing", async () => {
+      const client = await connectCoreClient();
+      const result = await client.callTool({
+        name: "get_configuration",
+        arguments: {},
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("Configuration ID is required");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("list_flexible_asset_types", () => {
+    it("lists the types with a 100-per-page window", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            {
+              id: "5",
+              type: "flexible-asset-types",
+              attributes: { name: "SSL Certificate" },
+            },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "list_flexible_asset_types",
+        arguments: {},
+      });
+
+      const url = decodedUrl();
+      expect(url).toContain("/flexible_asset_types?");
+      expect(url).toContain("page[size]=100");
+      expect(url).not.toContain("filter[");
+      expect(firstText(result)).toContain("SSL Certificate");
+    });
+
+    it("scopes the types to an organization when one is given", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(createJsonApiResponse([]))
+      );
+
+      await client.callTool({
+        name: "list_flexible_asset_types",
+        arguments: { organization_id: 123 },
+      });
+
+      expect(decodedUrl()).toContain("filter[organization-id]=123");
+    });
+  });
+
+  describe("search_flexible_assets", () => {
+    it("refuses to search without flexible_asset_type_id", async () => {
+      const client = await connectCoreClient();
+      const result = await client.callTool({
+        name: "search_flexible_assets",
+        arguments: { organization_id: 1 },
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("flexible_asset_type_id is required");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("filters by the flexible asset type id", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            {
+              id: "1",
+              type: "flexible-assets",
+              attributes: { name: "Network Asset" },
+            },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "search_flexible_assets",
+        arguments: { flexible_asset_type_id: 5 },
+      });
+
+      const url = decodedUrl();
+      expect(url).toContain("/flexible_assets?");
+      expect(url).toContain("filter[flexible-asset-type-id]=5");
+      expect(firstText(result)).toContain("Network Asset");
+    });
+
+    it("adds the organization and name filters alongside the type", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(createJsonApiResponse([]))
+      );
+
+      await client.callTool({
+        name: "search_flexible_assets",
+        arguments: {
+          flexible_asset_type_id: 5,
+          organization_id: 123,
+          name: "wildcard",
+        },
+      });
+
+      const url = decodedUrl();
+      expect(url).toContain("filter[flexible-asset-type-id]=5");
+      expect(url).toContain("filter[organization-id]=123");
+      expect(url).toContain("filter[name]=wildcard");
+    });
+  });
+
+  describe("itglue_health_check", () => {
+    it("probes /organization_types and reports the region and the count", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse(
+            [
+              {
+                id: "1",
+                type: "organization-types",
+                attributes: { name: "Customer" },
+              },
+            ],
+            { "total-count": 5 }
+          )
+        )
+      );
+
+      const result = await client.callTool({
+        name: "itglue_health_check",
+        arguments: {},
+      });
+
+      const url = decodedUrl();
+      expect(url).toContain("/organization_types?");
+      expect(url).toContain("page[size]=1");
+
+      expect(isError(result)).toBe(false);
+      const payload = JSON.parse(firstText(result));
+      expect(payload).toMatchObject({
+        status: "ok",
+        region: "us",
+        organizationTypesFound: 5,
+      });
+    });
+
+    it("reports an authentication failure as an error result", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockResolvedValueOnce(
+        createErrorResponse(401, "Invalid API Key")
+      );
+
+      const result = await client.callTool({
+        name: "itglue_health_check",
+        arguments: {},
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("401");
+      expect(firstText(result)).toContain("Invalid API Key");
+    });
+
+    it("reports an unreachable API as an error result", async () => {
+      const client = await connectCoreClient();
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await client.callTool({
+        name: "itglue_health_check",
+        arguments: {},
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("Network error");
+    });
+  });
+});
+
+// Round-trip coverage for the document section / lifecycle tools. The previous
+// tests here asserted on request payloads the test itself had built; one of
+// them ("should include resource relationship in document section payload")
+// asserted the exact opposite of what the handler does, because it was never
+// run against the handler.
+describe("Document section tools (round-trip)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function connectSectionsClient(): Promise<Client> {
+    const server = createMcpServer({ apiKey: "test-api-key" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "sections-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  function firstText(result: unknown): string {
+    const r = result as { content?: Array<{ text?: string }> };
+    return r.content?.[0]?.text ?? "";
+  }
+
+  function isError(result: unknown): boolean {
+    return (result as { isError?: boolean }).isError === true;
+  }
+
+  function requestOf(callIndex = 0): { url: string; init: RequestInit } {
+    const [url, init] = mockFetch.mock.calls[callIndex];
+    return { url: url as string, init: init as RequestInit };
+  }
+
+  function bodyOf(callIndex = 0): Record<string, unknown> {
+    return JSON.parse(requestOf(callIndex).init.body as string);
+  }
+
+  describe("list_document_sections", () => {
+    it("reads the document's sections relationship", async () => {
+      const client = await connectSectionsClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(
+          createJsonApiResponse([
+            {
+              id: "1001",
+              type: "document-sections",
+              attributes: { content: "<h2>Overview</h2>", position: 1 },
+            },
+          ])
+        )
+      );
+
+      const result = await client.callTool({
+        name: "list_document_sections",
+        arguments: { document_id: 789 },
+      });
+
+      expect(requestOf().url).toBe(
+        "https://api.itglue.com/documents/789/relationships/sections"
+      );
+      expect(requestOf().init.method).toBe("GET");
+      expect(firstText(result)).toContain("Overview");
+    });
+
+    it("returns an error without calling the API when document_id is missing", async () => {
+      const client = await connectSectionsClient();
+      const result = await client.callTool({
+        name: "list_document_sections",
+        arguments: {},
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("document_id is required");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("create_document_section", () => {
+    // IT Glue stores the section kind in the `resource_type` ATTRIBUTE. A
+    // `relationships.resource` binding is rejected with a 400 for a missing
+    // `resource_type` (verified live 2026-04-23), so the payload must carry the
+    // attribute and no relationships member.
+    it.each([
+      ["heading", "Document::Heading"],
+      ["text", "Document::Text"],
+    ])("maps section_type '%s' to resource_type %s", async (arg, apiValue) => {
+      const client = await connectSectionsClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: "1003",
+            type: "document-sections",
+            attributes: { content: "<p>New section.</p>" },
+          },
+        })
+      );
+
+      await client.callTool({
+        name: "create_document_section",
+        arguments: {
+          document_id: 789,
+          section_type: arg,
+          content: "<p>New section.</p>",
+        },
+      });
+
+      const { url, init } = requestOf();
+      expect(url).toBe(
+        "https://api.itglue.com/documents/789/relationships/sections"
+      );
+      expect(init.method).toBe("POST");
+
+      const body = bodyOf() as {
+        data: {
+          type: string;
+          attributes: Record<string, unknown>;
+          relationships?: unknown;
+        };
+      };
+      expect(body.data.type).toBe("document-sections");
+      expect(body.data.attributes.resource_type).toBe(apiValue);
+      expect(body.data.attributes.content).toBe("<p>New section.</p>");
+      expect(body.data.relationships).toBeUndefined();
+    });
+
+    it("rejects a section_type outside heading/text before calling the API", async () => {
+      const client = await connectSectionsClient();
+      const result = await client.callTool({
+        name: "create_document_section",
+        arguments: {
+          document_id: 789,
+          section_type: "table",
+          content: "<p>x</p>",
+        },
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("'heading' or 'text'");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("requires document_id, section_type and content", async () => {
+      const client = await connectSectionsClient();
+      const result = await client.callTool({
+        name: "create_document_section",
+        arguments: { document_id: 789 },
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain(
+        "document_id, section_type, and content are required"
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("surfaces an IT Glue 400 instead of reporting a created section", async () => {
+      const client = await connectSectionsClient();
+      mockFetch.mockResolvedValueOnce(
+        createErrorResponse(
+          400,
+          JSON.stringify({
+            errors: [
+              {
+                title: "Bad Request",
+                detail: "param is missing or the value is empty: resource_type",
+                status: "400",
+              },
+            ],
+          })
+        )
+      );
+
+      const result = await client.callTool({
+        name: "create_document_section",
+        arguments: {
+          document_id: 789,
+          section_type: "text",
+          content: "<p>x</p>",
+        },
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("400");
+      expect(firstText(result)).toContain("resource_type");
+    });
+  });
+
+  describe("update_document_section", () => {
+    it("PATCHes the section with the new content", async () => {
+      const client = await connectSectionsClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: "1002",
+            type: "document-sections",
+            attributes: { content: "<p>Updated.</p>" },
+          },
+        })
+      );
+
+      const result = await client.callTool({
+        name: "update_document_section",
+        arguments: {
+          document_id: 789,
+          section_id: 1002,
+          content: "<p>Updated.</p>",
+        },
+      });
+
+      const { url, init } = requestOf();
+      expect(url).toBe(
+        "https://api.itglue.com/documents/789/relationships/sections/1002"
+      );
+      expect(init.method).toBe("PATCH");
+      expect(bodyOf()).toEqual({
+        data: {
+          type: "document-sections",
+          attributes: { content: "<p>Updated.</p>" },
+        },
+      });
+      expect(firstText(result)).toContain("Updated.");
+    });
+
+    it("requires document_id, section_id and content", async () => {
+      const client = await connectSectionsClient();
+      const result = await client.callTool({
+        name: "update_document_section",
+        arguments: { document_id: 789, section_id: 1002 },
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain(
+        "document_id, section_id, and content are required"
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("delete_document_section", () => {
+    it("DELETEs the section and confirms by id", async () => {
+      const client = await connectSectionsClient();
+      mockFetch.mockResolvedValueOnce(createMockResponse(null, 204));
+
+      const result = await client.callTool({
+        name: "delete_document_section",
+        arguments: { document_id: 789, section_id: 1002 },
+      });
+
+      const { url, init } = requestOf();
+      expect(url).toBe(
+        "https://api.itglue.com/documents/789/relationships/sections/1002"
+      );
+      expect(init.method).toBe("DELETE");
+      expect(isError(result)).toBe(false);
+      expect(firstText(result)).toContain("Section 1002 deleted successfully");
+    });
+
+    it("requires document_id and section_id", async () => {
+      const client = await connectSectionsClient();
+      const result = await client.callTool({
+        name: "delete_document_section",
+        arguments: { document_id: 789 },
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain(
+        "document_id and section_id are required"
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("publish_document", () => {
+    // POST /documents/:id/publish returns 404 — the verb is load-bearing.
+    it("PATCHes /documents/:id/publish", async () => {
+      const client = await connectSectionsClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: {
+            id: "789",
+            type: "documents",
+            attributes: { name: "My Doc", published: true },
+          },
+        })
+      );
+
+      const result = await client.callTool({
+        name: "publish_document",
+        arguments: { document_id: 789 },
+      });
+
+      const { url, init } = requestOf();
+      expect(url).toBe("https://api.itglue.com/documents/789/publish");
+      expect(init.method).toBe("PATCH");
+      expect(firstText(result)).toContain("My Doc");
+    });
+
+    it("requires document_id", async () => {
+      const client = await connectSectionsClient();
+      const result = await client.callTool({
+        name: "publish_document",
+        arguments: {},
+      });
+
+      expect(isError(result)).toBe(true);
+      expect(firstText(result)).toContain("document_id is required");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("archive_document / unarchive_document", () => {
+    // Pins the URL, verb and payload so a refactor can't silently omit
+    // `archived` or invent a non-existent /archive sub-endpoint.
+    it.each([
+      ["archive_document", true],
+      ["unarchive_document", false],
+    ])("%s PATCHes /documents/:id with archived=%s", async (tool, archived) => {
+      const client = await connectSectionsClient();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          data: { id: "789", type: "documents", attributes: { archived } },
+        })
+      );
+
+      await client.callTool({
+        name: tool as string,
+        arguments: { document_id: 789 },
+      });
+
+      const { url, init } = requestOf();
+      expect(url).toBe("https://api.itglue.com/documents/789");
+      expect(init.method).toBe("PATCH");
+      expect(bodyOf()).toEqual({
+        data: { type: "documents", attributes: { archived } },
+      });
+    });
+
+    it.each(["archive_document", "unarchive_document"])(
+      "%s requires document_id",
+      async (tool) => {
+        const client = await connectSectionsClient();
+        const result = await client.callTool({ name: tool, arguments: {} });
+
+        expect(isError(result)).toBe(true);
+        expect(firstText(result)).toContain("document_id is required");
+        expect(mockFetch).not.toHaveBeenCalled();
+      }
+    );
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export {
   requestDocumentsWithFolderDefault,
   rootLevelDocumentsNote,
   stripDocumentBodies,
+  stripPasswordValues,
 } from "./mcp-server.js";
 export type {
   DocumentSearchAttempt,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -645,6 +645,37 @@ export function documentBodyOmittedNote(): string {
   );
 }
 
+/**
+ * Warning attached to a `search_*` result that ran WITHOUT an organization
+ * filter.
+ *
+ * These tools try to scope themselves by eliciting an organization name when
+ * `organization_id` is omitted. Elicitation is unavailable on any client that
+ * doesn't support it — notably through the MCP gateway, which does not proxy
+ * server-initiated requests — and the helpers return null there, so the search
+ * silently widened to the whole account. A caller that asked for "the VPN
+ * password for Acme" then received an arbitrary page drawn from every
+ * organization and reasonably concluded the entry did not exist.
+ *
+ * The query still runs (organization_id is genuinely optional — an account-wide
+ * search is a legitimate request). What changes is that the result now says
+ * which search actually happened, so an unscoped miss can't be read as proof of
+ * absence.
+ */
+export function unscopedSearchNote(
+  resource: string,
+  meta: PaginationMeta
+): string {
+  return (
+    `NOTE: no organization_id was supplied and this client could not be asked for one, ` +
+    `so this searched ${resource} across ALL organizations — returning page ${meta.currentPage} ` +
+    `of ${meta.totalPages} (${meta.totalCount} matching entries account-wide). ` +
+    `An empty or unexpected result here does NOT mean the entry is absent. ` +
+    `To scope the search, call search_organizations to find the organization's id, ` +
+    `then re-run this tool with organization_id set.`
+  );
+}
+
 /** Which filter form ultimately produced a `search_documents` listing. */
 export type DocumentSearchAttempt = "null-filter" | "ne-filter" | "unfiltered";
 
@@ -1788,13 +1819,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
 
         const result = await client.request("/configurations", params);
+        const configText = [
+          configOrgId === undefined
+            ? unscopedSearchNote("configurations", result.meta)
+            : "",
+          JSON.stringify(result, null, 2),
+        ]
+          .filter(Boolean)
+          .join("\n\n");
         return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
+          content: [{ type: "text", text: configText }],
         };
       }
 
@@ -1867,13 +1901,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
 
         const result = await client.request("/locations", params);
+        const locText = [
+          locOrgId === undefined ? unscopedSearchNote("locations", result.meta) : "",
+          JSON.stringify(result, null, 2),
+        ]
+          .filter(Boolean)
+          .join("\n\n");
         return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
+          content: [{ type: "text", text: locText }],
         };
       }
 
@@ -2009,13 +2044,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         params.show_password = false;
 
         const result = await client.request("/passwords", params);
+        const pwText = [
+          pwOrgId === undefined ? unscopedSearchNote("passwords", result.meta) : "",
+          JSON.stringify(result, null, 2),
+        ]
+          .filter(Boolean)
+          .join("\n\n");
         return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
+          content: [{ type: "text", text: pwText }],
         };
       }
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -612,6 +612,22 @@ export function folderedDocumentsIncludedNote(): string {
 }
 
 /**
+ * Drop one top-level field from every resource in a list result.
+ *
+ * `deserializeResource` flattens `attributes` and camelCases the keys, so the
+ * fields these list tools want to withhold sit at the top level of each record.
+ */
+function omitResourceField(items: unknown[], field: string): unknown[] {
+  return items.map((item) => {
+    if (item && typeof item === "object" && field in item) {
+      const { [field]: _omitted, ...rest } = item as Record<string, unknown>;
+      return rest;
+    }
+    return item;
+  });
+}
+
+/**
  * Strip each document's full body from a `search_documents` listing.
  *
  * IT Glue's documents list endpoint embeds every document's full sectioned body
@@ -623,17 +639,25 @@ export function folderedDocumentsIncludedNote(): string {
  * retrieval stays with get_document / list_document_sections.
  *
  * Coupled to IT Glue's current field name: the body arrives as a top-level
- * `content` key (deserializeResource flattens `attributes` and camelCases keys).
- * If IT Glue renames the body field or adds another heavy one, revisit this.
+ * `content` key. If IT Glue renames the body field or adds another heavy one,
+ * revisit this.
  */
 export function stripDocumentBodies(docs: unknown[]): unknown[] {
-  return docs.map((doc) => {
-    if (doc && typeof doc === "object" && "content" in doc) {
-      const { content: _body, ...rest } = doc as Record<string, unknown>;
-      return rest;
-    }
-    return doc;
-  });
+  return omitResourceField(docs, "content");
+}
+
+/**
+ * Remove secret material from a `search_passwords` listing.
+ *
+ * `search_passwords` asks IT Glue not to send secrets (`show_password=false`),
+ * but that is a request, not a guarantee: it is one query parameter away from
+ * being dropped by a refactor, and a tenant or API version that ignores it would
+ * spill every matched secret into the model's context in a single bulk listing.
+ * Reading a secret is `get_password`'s job — one id at a time, deliberately — so
+ * the list tool strips the value on the way out regardless of what came back.
+ */
+export function stripPasswordValues(passwords: unknown[]): unknown[] {
+  return omitResourceField(passwords, "password");
 }
 
 /** Advisory that document bodies are omitted from `search_documents` results. */
@@ -650,30 +674,56 @@ export function documentBodyOmittedNote(): string {
  * filter.
  *
  * These tools try to scope themselves by eliciting an organization name when
- * `organization_id` is omitted. Elicitation is unavailable on any client that
- * doesn't support it — notably through the MCP gateway, which does not proxy
- * server-initiated requests — and the helpers return null there, so the search
- * silently widened to the whole account. A caller that asked for "the VPN
- * password for Acme" then received an arbitrary page drawn from every
- * organization and reasonably concluded the entry did not exist.
+ * `organization_id` is omitted. That can fail to produce a scope in several
+ * ways: elicitation is unavailable on any client that doesn't support it
+ * — notably through the MCP gateway, which does not proxy server-initiated
+ * requests — the user can decline, and the name they give can match no
+ * organization at all. Every one of those paths silently widened the search to
+ * the whole account. A caller that asked for "the VPN password for Acme" then
+ * received an arbitrary page drawn from every organization and reasonably
+ * concluded the entry did not exist.
  *
  * The query still runs (organization_id is genuinely optional — an account-wide
  * search is a legitimate request). What changes is that the result now says
  * which search actually happened, so an unscoped miss can't be read as proof of
- * absence.
+ * absence. The wording deliberately does not blame a particular cause: the
+ * handler can't tell "could not ask" from "asked, and nothing matched", and
+ * naming the wrong one sends the reader after the wrong fix.
  */
 export function unscopedSearchNote(
   resource: string,
   meta: PaginationMeta
 ): string {
   return (
-    `NOTE: no organization_id was supplied and this client could not be asked for one, ` +
-    `so this searched ${resource} across ALL organizations — returning page ${meta.currentPage} ` +
+    `NOTE: this search was NOT scoped to an organization — no organization_id was ` +
+    `supplied and one could not be determined, ` +
+    `so it searched ${resource} across ALL organizations — returning page ${meta.currentPage} ` +
     `of ${meta.totalPages} (${meta.totalCount} matching entries account-wide). ` +
     `An empty or unexpected result here does NOT mean the entry is absent. ` +
     `To scope the search, call search_organizations to find the organization's id, ` +
     `then re-run this tool with organization_id set.`
   );
+}
+
+/**
+ * The unscoped-search warning, emitted only when no organization filter
+ * actually went out on the wire.
+ *
+ * Deliberately keyed off the built filter rather than the caller's raw
+ * `organization_id`. The handlers apply the filter under `if (orgId)` but the
+ * warning used to be gated on `orgId === undefined`, so a falsy-but-present id
+ * (`0`, or the `NaN` from `Number(<non-numeric id>)` after an elicited lookup)
+ * fell through the gap: the scope was dropped AND the warning suppressed. One
+ * helper reading the filter keeps the two from drifting apart again.
+ */
+function unscopedSearchNoteFor(
+  resource: string,
+  filter: Record<string, unknown>,
+  meta: PaginationMeta
+): string {
+  return filter.organizationId === undefined
+    ? unscopedSearchNote(resource, meta)
+    : "";
 }
 
 /** Which filter form ultimately produced a `search_documents` listing. */
@@ -1820,9 +1870,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         const result = await client.request("/configurations", params);
         const configText = [
-          configOrgId === undefined
-            ? unscopedSearchNote("configurations", result.meta)
-            : "",
+          unscopedSearchNoteFor("configurations", filter, result.meta),
           JSON.stringify(result, null, 2),
         ]
           .filter(Boolean)
@@ -1902,7 +1950,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         const result = await client.request("/locations", params);
         const locText = [
-          locOrgId === undefined ? unscopedSearchNote("locations", result.meta) : "",
+          unscopedSearchNoteFor("locations", filter, result.meta),
           JSON.stringify(result, null, 2),
         ]
           .filter(Boolean)
@@ -2044,9 +2092,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         params.show_password = false;
 
         const result = await client.request("/passwords", params);
+        const redacted = {
+          ...result,
+          data: stripPasswordValues(result.data as unknown[]),
+        };
         const pwText = [
-          pwOrgId === undefined ? unscopedSearchNote("passwords", result.meta) : "",
-          JSON.stringify(result, null, 2),
+          unscopedSearchNoteFor("passwords", filter, result.meta),
+          JSON.stringify(redacted, null, 2),
         ]
           .filter(Boolean)
           .join("\n\n");

--- a/src/utils/elicitation.ts
+++ b/src/utils/elicitation.ts
@@ -10,6 +10,27 @@ export interface ElicitOption {
 }
 
 /**
+ * Record that an elicitation prompt could not be delivered.
+ *
+ * Failing here is expected, not exceptional: any client that doesn't declare
+ * the elicitation capability makes `elicitInput()` throw, and the MCP gateway
+ * does not proxy server-initiated requests at all — so every gateway-mode
+ * request takes this path. Returning null and degrading is therefore correct.
+ *
+ * What was wrong was doing it *silently*: a bare `catch {}` turned "the user
+ * could not be asked" into "the user said nothing", callers widened their
+ * query, and nothing anywhere recorded that a prompt had been dropped. Logged
+ * to stderr because stdout is the stdio transport's protocol channel.
+ */
+function noteElicitationUnavailable(reason: unknown): void {
+  const detail = reason instanceof Error ? reason.message : String(reason);
+  console.error(
+    `[itglue-mcp] elicitation unavailable (${detail}) — continuing without user input; ` +
+      `callers fall back to an unscoped request.`
+  );
+}
+
+/**
  * Ask the user to select from a list of options.
  */
 export async function elicitSelection(
@@ -18,7 +39,10 @@ export async function elicitSelection(
   options: ElicitOption[]
 ): Promise<string | null> {
   const server = getServerRef();
-  if (!server) return null;
+  if (!server) {
+    noteElicitationUnavailable("no server bound to this request context");
+    return null;
+  }
 
   try {
     const result = await server.elicitInput({
@@ -42,7 +66,8 @@ export async function elicitSelection(
       return result.content[fieldName] as string;
     }
     return null;
-  } catch {
+  } catch (err) {
+    noteElicitationUnavailable(err);
     return null;
   }
 }
@@ -56,7 +81,10 @@ export async function elicitText(
   description?: string
 ): Promise<string | null> {
   const server = getServerRef();
-  if (!server) return null;
+  if (!server) {
+    noteElicitationUnavailable("no server bound to this request context");
+    return null;
+  }
 
   try {
     const result = await server.elicitInput({
@@ -78,7 +106,8 @@ export async function elicitText(
       return result.content[fieldName] as string;
     }
     return null;
-  } catch {
+  } catch (err) {
+    noteElicitationUnavailable(err);
     return null;
   }
 }
@@ -90,7 +119,10 @@ export async function elicitConfirmation(
   message: string
 ): Promise<boolean | null> {
   const server = getServerRef();
-  if (!server) return null;
+  if (!server) {
+    noteElicitationUnavailable("no server bound to this request context");
+    return null;
+  }
 
   try {
     const result = await server.elicitInput({
@@ -112,7 +144,8 @@ export async function elicitConfirmation(
       return result.content.confirm as boolean;
     }
     return null;
-  } catch {
+  } catch (err) {
+    noteElicitationUnavailable(err);
     return null;
   }
 }


### PR DESCRIPTION
## Why

The suite was green, but much of it was hollow. The pattern was uniform: mock global `fetch`, then call `fetch` **directly** and assert on the payload the mock was just handed. The handler never ran, so the test could not fail.

The purest case was `describe("Request Headers")` — it built a headers object, passed it to `fetch`, and asserted the mock had captured those same values. It never touched `ITGlueClient.authHeaders()`.

**Measured before this PR:** 25 tools defined, 11 with a real `client.callTool` round-trip test, **14 with none**, and 27 hollow tests.

## What changed

### Real bugs found by making the tests actually run the handlers

Three shipped defects, all invisible while the tests only inspected their own mocks:

1. **`search_passwords` could return plaintext secrets.** The handler sends `show_password=false`, but that is a request to IT Glue, not a guarantee — one refactor from being dropped, and a tenant or API version that ignores it spills every matched secret into the model's context in a single bulk listing. The test that claimed to cover this ("never returns a password value even if the API sends one") used a fixture with **no password in it**, so it passed against a handler with no redaction at all. Now redacted on the way out; `get_password` still returns the secret, and a test pins that asymmetry.

2. **The account-wide-search warning vanished exactly when it was needed.** The org filter is applied under `if (orgId)`, but the warning was gated on `orgId === undefined`. A falsy-but-present id — `0`, or the `NaN` from `Number(<non-numeric id>)` after an elicited lookup — dropped the scope **and** suppressed the warning: precisely the silent account-wide search the warning exists to prevent. Both now derive from the filter that actually went out, via one helper.

3. **The warning misattributed its own cause.** It said the client "could not be asked" even when the user was asked, answered, and the org lookup matched nothing — sending the reader after a gateway problem that wasn't there.

### One hollow test asserted the *opposite* of shipped behaviour

`"should include resource relationship in document section payload"` expected `create_document_section` to send a `relationships.resource` binding. The handler deliberately does not — IT Glue stores the kind in the `resource_type` **attribute**, and a relationships binding is rejected with a 400 (verified live 2026-04-23, per the handler's comment). Because the test only inspected a payload it built itself, the contradiction sat undetected.

### Coverage

All **25 tools** now have real round-trip coverage via the existing `InMemoryTransport` idiom.

- `Request Headers` / `Error Handling` now drive a real `ITGlueClient`.
- New `Core tools (round-trip)`: organizations, configurations, flexible assets, health check.
- New `Document section tools (round-trip)`: section CRUD, `publish_document`, archive/unarchive.
- `Unknown Tool Handling` asserted `knownTools.length === 9` against a literal the test itself wrote while the server registers 25 — it now drives the server and checks every advertised tool reaches a real branch.
- Purely circular tests were **deleted**, not rewritten. A test that cannot fail is worse than no test: it buys false confidence. Where deleting would have lost genuine coverage (the header assertion), it was replaced with a real one.
- Closes the loose end from the prior commit: `unscopedSearchNote()` was wired into `search_configurations` and `search_locations` too, but only `search_passwords` had tests. All three are now covered.

## Verification

Every conversion was **mutation-checked** — deliberately breaking each handler makes its new test fail (6 seeded mutations, 7 failures; then 2 more for the new fixes, both caught).

```
npm ci        ok
npm run build ok
npm test      262 passed (5 files)
npm run typecheck ok
npm run lint  ok
```

**E2E over stdio** (spawned `node dist/index.js`, JSON-RPC `initialize` → `notifications/initialized` → `tools/list`):

```
initialize -> itglue-mcp 1.0.0
tools.length = 25
PASS: 25 tools served over stdio
```

The tool surface is unchanged by the refactor.
