### PR TITLE
fix(ci): adopt upstream mcpb job, drop the local stopgap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
       id-token: write
       security-events: write
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@8deff2993e933c45856861cb3491d251361a5a8a
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@8bfc9b3a249fd1e6f69f1d05c45c8eaf3076fec3
     with:
       server-name: itglue-mcp
       image-name: ghcr.io/wyre-technology/itglue-mcp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,54 +22,12 @@ jobs:
       packages: write
       id-token: write
       security-events: write
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@d28a612a00a1bd0c36aff09e686ce2d1e10ef552
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@8deff2993e933c45856861cb3491d251361a5a8a
     with:
       server-name: itglue-mcp
       image-name: ghcr.io/wyre-technology/itglue-mcp
     secrets: inherit
 
-  # The reusable pipeline does not pack or attach the Claude Desktop .mcpb
-  # bundle (dropped when the hand-rolled workflow was replaced in #61, which
-  # is why v1.13.0 shipped with no assets). Restore it here until the step
-  # is upstreamed into mcp-server-release.yml.
-  mcpb:
-    name: Pack and upload MCPB bundle
-    runs-on: ubuntu-latest
-    needs: release
-    if: needs.release.outputs.released == 'true'
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.release.outputs.tag_name }}
-      - uses: actions/setup-node@v7
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - name: Stamp released version into package.json
-        # semantic-release does not commit the version bump back to the repo,
-        # and pack-mcpb.cjs copies package.json's version into manifest.json.
-        # Without this stamp the bundle ships with a stale version (v1.12.0's
-        # bundle said 1.5.3).
-        env:
-          VERSION: ${{ needs.release.outputs.version }}
-        run: npm version "$VERSION" --no-git-tag-version
-      - name: Pack MCPB bundle
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          npm install -g @anthropic-ai/mcpb
-          npm run pack:mcpb
-      - name: Upload bundle to GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release.outputs.tag_name }}
-        run: |
-          BUNDLE_NAME=$(node -p "require('./package.json').name.replace(/^@.*\\//, '')")
-          gh release upload "$TAG_NAME" "${BUNDLE_NAME}.mcpb" \
-            --repo "${{ github.repository }}" --clobber
 
   deploy:
     needs: release


### PR DESCRIPTION
This repo is the only one in the fleet still shipping a `.mcpb`, via a local stopgap job whose own comment reads:

> Restore it here **until the step is upstreamed into mcp-server-release.yml**.

It has been upstreamed ([wyre-technology/.github#43](https://github.com/wyre-technology/.github/pull/43)). This PR bumps the pin `d28a612` → `8deff29` to pick it up and removes the local job.

## Why the upstream job is a safe replacement

It is a strict superset of the stopgap — same checkout-tag → stamp-version → pack → upload sequence, plus:

- an explicit `npm ci` (the stopgap relied on `pack:mcpb` bootstrapping its own dependencies)
- GitHub Packages auth for `@wyre-technology/*` deps
- a glob upload that does not hardcode the bundle filename
- `needs: [release]` only, never `docker`, so a pack failure cannot cascade into skipping deploy

It keeps the stopgap's load-bearing `npm version --no-git-tag-version` stamp, for the reason your comment already documents: semantic-release does not commit its bump back, so packing the tag as-is ships a stale version (your note records v1.12.0's bundle saying 1.5.3).

Leaving both in place would pack twice and upload the same asset twice with `--clobber` — harmless, but wasteful and confusing.

## Verification

`jobs` is now `[release, deploy]`; YAML parses; the `mcp-server-deploy.yml` pin is untouched. Pin range diffed before bumping: 4 commits, netting the `mcpb` job plus #40's provenance/digest-verify hardening — a combination that has since run green end-to-end (build, bundle, registry, security, deploy) three consecutive times on autotask-mcp, v2.32.7 through v2.32.9.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/itglue-mcp/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->